### PR TITLE
Allow exclusion of test module dependencies (add --production)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1946,9 +1946,9 @@
       }
     },
     "generic-pool": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
-      "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.5.0.tgz",
+      "integrity": "sha512-dEkxmX+egB2o4NR80c/q+xzLLzLX+k68/K8xv81XprD+Sk7ZtP14VugeCz+fUwv5FzpWq40pPtAkzPRqT8ka9w=="
     },
     "get-value": {
       "version": "2.0.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ function run() {
         --threads, -t           Maximum number of threads to run in parallel
         --localonly, -l         Enable to not scan other directories than CWD for plugins
         --verbose, -v           Enable verbose logging
+        --production, -P        Enable production mode (ignores test dependencies)
 `, {
         flags: {
             plugin: {
@@ -61,6 +62,11 @@ function run() {
                 type: 'boolean',
                 alias: 'v',
                 default: false
+            },
+            production: {
+                type: 'boolean',
+                alias: 'P',
+                default: false
             }
         }
     });
@@ -71,6 +77,10 @@ function run() {
     }
     if (cli.flags.watch && cli.flags.onlypre) {
         console.error(cerr`--watch and --onlypre cannot be enabled simultaneously`);
+        process.exit(1);
+    }
+    if (cli.flags.production && cli.flags.onlypre) {
+        console.error(cerr`--production and --onlypre cannot be enabled simultaneously`);
         process.exit(1);
     }
     if (cli.flags.threads !== null) {
@@ -93,7 +103,8 @@ function run() {
         onlyPreprocessing: cli.flags.onlypre,
         clean: cli.flags.clean,
         maxParallelism: !!cli.flags.threads ? cli.flags.threads : os.cpus().length - 1,
-        localOnly: cli.flags.localonly
+        localOnly: cli.flags.localonly,
+        production: cli.flags.production
     };
 
     console.log(getAvailableStats());

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -39,6 +39,11 @@ export interface IAssetsCompilerConfiguration {
      * Indicates whether only the current directory should be processed for plugins
      */
     localOnly: boolean;
+
+    /**
+     * Indicates whether the compiler should be run in production mode
+     */
+    production: boolean;
 }
 
 /**
@@ -142,7 +147,8 @@ export class AssetsCompiler {
                     && fs.existsSync(path.join(filePath, `${potentialPluginName}.iml`))) {
                     AssetsCompiler.addProjectDependenciesRecursively(
                         projects, this.mainRepoPath, knownRepoDependencies,
-                        potentialPluginName, filePath, this.runConfig.localOnly);
+                        potentialPluginName, filePath,
+                        this.runConfig.localOnly, this.runConfig.production);
                 }
             }
         });
@@ -184,12 +190,14 @@ export class AssetsCompiler {
                                                      repoDependencies: string[],
                                                      pluginName: string,
                                                      pluginPath: string,
-                                                     localOnly: boolean) {
+                                                     localOnly: boolean,
+                                                     excludeTestDependencies: boolean) {
         if (projects.has(pluginName)) {
             return;
         }
 
         const project = new CplacePlugin(pluginName, pluginPath, mainRepoPath, localOnly);
+        project.parseDependencies(excludeTestDependencies);
         projects.set(pluginName, project);
 
         project.dependencies.forEach(depName => {
@@ -197,7 +205,7 @@ export class AssetsCompiler {
                 return;
             }
             const pluginPath = this.findPluginPath(depName, repoDependencies);
-            this.addProjectDependenciesRecursively(projects, mainRepoPath, repoDependencies, depName, pluginPath, localOnly);
+            this.addProjectDependenciesRecursively(projects, mainRepoPath, repoDependencies, depName, pluginPath, localOnly, excludeTestDependencies);
         });
     }
 


### PR DESCRIPTION
Adds a new `--production|-P` flag which will cause the compiler to exclude modules that are marked as test dependencies. As such, compiling TypeScript code that references "Test" dependencies cannot be compiled in production mode.