### PR TITLE
Generate Sourcemaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -460,6 +460,14 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -2401,6 +2409,11 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -3417,6 +3430,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
       "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+    },
+    "source-map-loader": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+      "requires": {
+        "async": "^2.5.0",
+        "loader-utils": "^1.1.0"
+      }
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "less": "^3.8.1",
     "meow": "^5.0.0",
     "rimraf": "^2.6.2",
+    "source-map-loader": "^0.2.4",
     "webpack": "^4.26.0",
     "xml2js": "^0.4.19"
   },

--- a/src/compiler/CompressCssCompiler.ts
+++ b/src/compiler/CompressCssCompiler.ts
@@ -15,7 +15,10 @@ export class CompressCssCompiler implements ICompiler {
     private readonly pathToCssSources: string;
     private readonly pathToEntryFile: string = '';
 
-    constructor(private readonly pluginName: string, private readonly assetsPath: string, private readonly mainRepoDir: string) {
+    constructor(private readonly pluginName: string,
+                private readonly assetsPath: string,
+                private readonly mainRepoDir: string,
+                private readonly isProduction: boolean) {
         this.pathToCssSources = path.join(this.assetsPath, CompressCssCompiler.CSS_SOURCES_DIR);
         this.pathToEntryFile = path.join(this.pathToCssSources, CompressCssCompiler.ENTRY_FILE_NAME);
     }

--- a/src/compiler/LessCompiler.ts
+++ b/src/compiler/LessCompiler.ts
@@ -13,7 +13,10 @@ export class LessCompiler implements ICompiler {
     private readonly pathToLessSources: string;
     private readonly pathToEntryFile: string = '';
 
-    constructor(private readonly pluginName: string, private readonly assetsPath: string, private readonly mainRepoDir: string) {
+    constructor(private readonly pluginName: string,
+                private readonly assetsPath: string,
+                private readonly mainRepoDir: string,
+                private readonly isProduction: boolean) {
         this.pathToLessSources = path.join(this.assetsPath, LessCompiler.LESS_SOURCES_DIR);
 
         for (const name of ['plugin', 'cplace']) {
@@ -56,11 +59,15 @@ export class LessCompiler implements ICompiler {
                         fs.mkdirSync(lessOutputDir);
                     }
 
+                    const promises = [
+                        writeFile(outputFile, output.css, 'utf8')
+                    ];
+                    if (!this.isProduction) {
+                        promises.push(writeFile(sourceMapFile, output.map, 'utf8'));
+                    }
+
                     return Promise
-                        .all([
-                            writeFile(outputFile, output.css, 'utf8'),
-                            writeFile(sourceMapFile, output.map, 'utf8')
-                        ])
+                        .all(promises)
                         .then(() => {
                             let end = new Date().getTime();
                             console.log(GREEN_CHECK, `[${this.pluginName}] LESS finished (${formatDuration(end - start)})`);

--- a/src/compiler/LessCompiler.ts
+++ b/src/compiler/LessCompiler.ts
@@ -6,6 +6,7 @@ import * as less from 'less';
 import {ICompiler} from './interfaces';
 import {cerr, cgreen, formatDuration, GREEN_CHECK} from '../utils';
 import {CompressCssCompiler} from './CompressCssCompiler';
+import Options = Less.Options;
 
 export class LessCompiler implements ICompiler {
     private static readonly LESS_SOURCES_DIR = 'less';
@@ -36,17 +37,25 @@ export class LessCompiler implements ICompiler {
         const entryFile = path.join(this.assetsPath, LessCompiler.LESS_SOURCES_DIR, `${filename}.less`);
         const lessOutputDir = CompressCssCompiler.getCssOutputDir(this.assetsPath);
         const outputFile = path.join(lessOutputDir, `${filename}.css`);
-        const sourceMapFile = path.join(lessOutputDir, `${filename}.map`);
+        const sourceMapFile = path.join(lessOutputDir, `${filename}.css.map`);
 
         const writeFile = promisify(fs.writeFile);
 
         const start = new Date().getTime();
         console.log(`⟲ [${this.pluginName}] starting LESS compilation...`);
         return new Promise<void>((resolve, reject) => {
+            const lesscOptions: Options = {
+                filename: path.resolve(entryFile)
+            };
+            if (!this.isProduction) {
+                lesscOptions.sourceMap = {
+                    sourceMapBasepath: path.join(this.assetsPath, LessCompiler.LESS_SOURCES_DIR),
+                    sourceMapRootpath: `../${LessCompiler.LESS_SOURCES_DIR}/`,
+                    sourceMapURL: `${filename}.css.map`
+                };
+            }
             less
-                .render(fs.readFileSync(entryFile, 'utf8'), {
-                    filename: path.resolve(entryFile)
-                })
+                .render(fs.readFileSync(entryFile, 'utf8'), lesscOptions)
                 .catch((err) => {
                     console.error(cerr`${err}`);
                     throw Error(`[${this.pluginName}] LESS compilation failed`);

--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -77,25 +77,26 @@ export class TypescriptCompiler implements ICompiler {
     }
 
     private getWebpackConfig(): Configuration {
-        return {
+        const config: Configuration = {
             context: path.resolve(this.assetsPath, TypescriptCompiler.DEST_DIR),
-            devtool: 'source-map',
             entry: {
                 tsc: './' + TypescriptCompiler.ENTRY
             },
             externals: this.externals,
             mode: 'development',
             module: {
-                rules: [{
-                    test: /\.js$/,
-                    exclude: /node_modules/,
-                    use: [{
-                        loader: path.resolve(__filename, '../contextInjectorLoader.js'),
-                        options: {
-                            entry: TypescriptCompiler.ENTRY
-                        }
-                    }]
-                }]
+                rules: [
+                    {
+                        test: /\.js$/,
+                        exclude: /node_modules/,
+                        use: [{
+                            loader: path.resolve(__filename, '../contextInjectorLoader.js'),
+                            options: {
+                                entry: TypescriptCompiler.ENTRY
+                            }
+                        }]
+                    }
+                ]
             },
             output: {
                 filename: '[name].js',
@@ -117,6 +118,21 @@ export class TypescriptCompiler implements ICompiler {
                 extensions: ['.ts', '.js']
             }
         };
+
+        if (!this.isProduction) {
+            config.devtool = 'source-map';
+            // @ts-ignore
+            config.module.rules.push({
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: [{
+                    loader: path.resolve(__filename, '../../../node_modules/source-map-loader')
+                }],
+                enforce: 'pre'
+            });
+        }
+
+        return config;
     }
 
     private resolveWebpackExternal(context: string, request: string, callback: Function) {

--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -22,7 +22,10 @@ export class TypescriptCompiler implements ICompiler {
         draggable: 'Draggable'
     }, this.resolveWebpackExternal.bind(this)];
 
-    constructor(private readonly pluginName: string, private readonly assetsPath: string, private readonly mainRepoDir: string) {
+    constructor(private readonly pluginName: string,
+                private readonly assetsPath: string,
+                private readonly mainRepoDir: string,
+                private readonly isProduction: boolean) {
     }
 
     public static getJavaScriptOutputDir(assetsPath: string): string {

--- a/src/compiler/contextInjectorLoader.ts
+++ b/src/compiler/contextInjectorLoader.ts
@@ -9,14 +9,14 @@ import {loader} from 'webpack';
     This file is configured by `TypescriptCompiler` as a loader for Webpack
  */
 
-export default function (this: loader.LoaderContext, content: string) {
+export default function (this: loader.LoaderContext, source: string, map: any) {
     // @ts-ignore
     if (this.resourcePath === path.resolve(this.rootContext, this.query.entry)) {
         const requireContext = '\n//======================================================\n' +
             'exports.default = require.context(".", true, /.js$/);\n' +
             '//======================================================\n';
 
-        return content + requireContext;
+        source = source + requireContext;
     }
-    return content;
+    this.callback(null, source, map);
 };

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -57,7 +57,12 @@ if (require.main === module) {
 
         let compiler;
         try {
-            compiler = new CompilerConstructor(request.pluginName, request.assetsPath, request.mainRepoDir);
+            compiler = new CompilerConstructor(
+                request.pluginName,
+                request.assetsPath,
+                request.mainRepoDir,
+                request.isProduction
+            );
         } catch (e) {
             console.error(cerr`${e.message}`);
             throw Error(e);

--- a/src/compiler/interfaces.d.ts
+++ b/src/compiler/interfaces.d.ts
@@ -2,6 +2,7 @@ export interface ICompileRequest {
     pluginName: string;
     assetsPath: string;
     mainRepoDir: string;
+    isProduction: boolean;
     verbose?: boolean;
     less?: boolean;
     ts?: boolean;
@@ -9,7 +10,10 @@ export interface ICompileRequest {
 }
 
 export interface ICompilerConstructor {
-    new(pluginName: string, assetsPath: string, mainRepoDir: string): ICompiler;
+    new(pluginName: string,
+        assetsPath: string,
+        mainRepoDir: string,
+        isProduction: boolean): ICompiler;
 }
 
 export interface ICompiler {

--- a/src/executor/Scheduler.ts
+++ b/src/executor/Scheduler.ts
@@ -34,7 +34,8 @@ export class Scheduler {
 
     constructor(private readonly executor: ExecutorService,
                 private readonly plugins: Map<string, CplacePlugin>,
-                private readonly watchFiles: boolean = false) {
+                private readonly isProduction: boolean,
+                private readonly watchFiles: boolean) {
         this.tsJobs = this.createTsJobTracker();
         this.lessJobs = this.createLessJobTracker();
         this.compressCssJobs = this.createCompressCssJobTracker();
@@ -108,7 +109,8 @@ export class Scheduler {
                 pluginName: plugin.pluginName,
                 assetsPath: plugin.assetsDir,
                 mainRepoDir: plugin.mainRepoDir,
-                verbose: isDebugEnabled(),
+                isProduction: this.isProduction,
+                verbose: isDebugEnabled()
             };
             compileRequest[compileType] = true;
 

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -83,7 +83,7 @@ export class AssetsCompiler {
         this.isSubRepo = AssetsCompiler.checkIsSubRepo();
         this.projects = this.setupProjects();
         this.executor = new ExecutorService(this.runConfig.maxParallelism);
-        this.scheduler = new Scheduler(this.executor, this.projects, this.runConfig.watchFiles);
+        this.scheduler = new Scheduler(this.executor, this.projects, this.runConfig.production, this.runConfig.watchFiles);
     }
 
     public async start(): Promise<void> {
@@ -155,7 +155,7 @@ export class AssetsCompiler {
 
         projects.forEach(project => {
             if (project.hasTypeScriptAssets) {
-                project.generateTsConfig(p => projects.get(p));
+                project.generateTsConfig(p => projects.get(p), this.runConfig.production);
             }
         });
 

--- a/src/model/CplacePlugin.ts
+++ b/src/model/CplacePlugin.ts
@@ -74,7 +74,7 @@ export default class CplacePlugin {
         return CplacePlugin.getPluginPathRelativeToRepo(sourceRepo, this.pluginName, this.repo, this.localOnly);
     }
 
-    public generateTsConfig(pluginResolver: ICplacePluginResolver): void {
+    public generateTsConfig(pluginResolver: ICplacePluginResolver, isProduction: boolean): void {
         if (!this.hasTypeScriptAssets) {
             throw Error(`[${this.pluginName}] plugin does not have TypeScript assets`);
         }
@@ -89,7 +89,7 @@ export default class CplacePlugin {
             })
             .filter(p => p.hasTypeScriptAssets);
 
-        const tsConfigGenerator = new TsConfigGenerator(this, dependenciesWithTypeScript, this.localOnly);
+        const tsConfigGenerator = new TsConfigGenerator(this, dependenciesWithTypeScript, this.localOnly, isProduction);
         const tsconfigPath = tsConfigGenerator.createConfigAndGetPath();
 
         if (!fs.existsSync(tsconfigPath)) {

--- a/src/model/TsConfigGenerator.ts
+++ b/src/model/TsConfigGenerator.ts
@@ -19,7 +19,8 @@ export class TsConfigGenerator {
 
     constructor(private readonly plugin: CplacePlugin,
                 private readonly dependencies: CplacePlugin[],
-                private readonly localOnly: boolean) {
+                private readonly localOnly: boolean,
+                private readonly isProduction: boolean) {
     }
 
     public createConfigAndGetPath(): string {
@@ -78,7 +79,9 @@ export class TsConfigGenerator {
             compilerOptions: {
                 rootDir: '.',
                 baseUrl: '.',
-                outDir: '../generated_js'
+                outDir: '../generated_js',
+                sourceMap: !this.isProduction,
+                declarationMap: !this.isProduction
             },
             include: [
                 './**/*.ts',


### PR DESCRIPTION
This PR enables the assets compiler to generate source maps for LESS and TypeScript when running in development mode - i.e. the `--production` flag is *not* set.

Fixes #1 