### PR TITLE
Show update hint after every compile step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -464,7 +464,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -901,6 +902,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1150,7 +1152,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "optional": true
     },
     "des.js": {
       "version": "1.0.0",
@@ -1431,7 +1434,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -1573,7 +1577,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1591,11 +1596,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1608,15 +1615,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1719,7 +1729,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1729,6 +1740,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1741,17 +1753,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1768,6 +1783,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1840,7 +1856,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1850,6 +1867,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1925,7 +1943,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1955,6 +1974,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1972,6 +1992,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2010,18 +2031,20 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
     "generic-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.6.1.tgz",
-      "integrity": "sha512-iMmD/pY4q0+V+f8o4twE9JPeqfNuX+gJAaIPB3B0W1lFkBOtTxBo6B0HxHPgGhzQA8jego7EWopcYq/UDJO2KA=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.7.1.tgz",
+      "integrity": "sha512-ug6DAZoNgWm6q5KhPFA+hzXfBLFQu5sTXxPpv44DmE0A2g+CiHoq9LTVdkXpZMkYVMoGw83F6W+WT0h0MFMK/w=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -2394,7 +2417,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2642,12 +2666,14 @@
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.21",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "optional": true,
       "requires": {
         "mime-db": "~1.37.0"
       }
@@ -3437,7 +3463,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "optional": true
     },
     "sax": {
       "version": "1.2.4",
@@ -3994,7 +4021,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/src/executor/Scheduler.ts
+++ b/src/executor/Scheduler.ts
@@ -37,7 +37,7 @@ export class Scheduler {
                 private readonly mainRepoDir: string,
                 private readonly isProduction: boolean,
                 private readonly watchFiles: boolean,
-                private readonly updateDetails: IUpdateDetails | null) {
+                private readonly updateDetails?: IUpdateDetails) {
         this.tsJobs = this.createTsJobTracker();
         this.lessJobs = this.createLessJobTracker();
         this.compressCssJobs = this.createCompressCssJobTracker();
@@ -87,14 +87,14 @@ export class Scheduler {
 
         if (nextTsPlugin === null && nextLessPlugin === null && nextCompressCssPlugin === null) {
             if (!this.watchFiles && !this.completed) {
-                this.updateDetails && printUpdateDetails(this.updateDetails);
+                printUpdateDetails(this.updateDetails);
                 this.completed = true;
                 this.finishedResolver && this.finishedResolver();
             } else if (this.watchFiles) {
                 console.log();
                 console.log(csucc`Compilation completed - watching files...`);
                 console.log();
-                this.updateDetails && printUpdateDetails(this.updateDetails);
+                printUpdateDetails(this.updateDetails);
             }
         } else if (nextTsPlugin || nextLessPlugin || nextCompressCssPlugin) {
             if (this.executor.hasCapacity()) {

--- a/src/executor/Scheduler.ts
+++ b/src/executor/Scheduler.ts
@@ -8,7 +8,7 @@ import {JobDetails, JobTracker} from './JobTracker';
 import * as path from 'path';
 import * as chokidar from 'chokidar';
 import {FSWatcher} from 'chokidar';
-import {cerr, csucc, debug, isDebugEnabled} from '../utils';
+import {cerr, csucc, debug, isDebugEnabled, IUpdateDetails, printUpdateDetails} from '../utils';
 import {ICompileRequest} from '../compiler/interfaces';
 import Timeout = NodeJS.Timeout;
 
@@ -36,7 +36,8 @@ export class Scheduler {
                 private readonly plugins: Map<string, CplacePlugin>,
                 private readonly mainRepoDir: string,
                 private readonly isProduction: boolean,
-                private readonly watchFiles: boolean) {
+                private readonly watchFiles: boolean,
+                private readonly updateDetails: IUpdateDetails | null) {
         this.tsJobs = this.createTsJobTracker();
         this.lessJobs = this.createLessJobTracker();
         this.compressCssJobs = this.createCompressCssJobTracker();
@@ -86,12 +87,14 @@ export class Scheduler {
 
         if (nextTsPlugin === null && nextLessPlugin === null && nextCompressCssPlugin === null) {
             if (!this.watchFiles && !this.completed) {
+                this.updateDetails && printUpdateDetails(this.updateDetails);
                 this.completed = true;
                 this.finishedResolver && this.finishedResolver();
             } else if (this.watchFiles) {
                 console.log();
                 console.log(csucc`Compilation completed - watching files...`);
                 console.log();
+                this.updateDetails && printUpdateDetails(this.updateDetails);
             }
         } else if (nextTsPlugin || nextLessPlugin || nextCompressCssPlugin) {
             if (this.executor.hasCapacity()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,16 @@
 
 import {getAvailableStats} from './model/utils';
 import {AssetsCompiler, IAssetsCompilerConfiguration} from './model/AssetsCompiler';
-import {cerr, checkForUpdate, debug, enableDebug, isDebugEnabled} from './utils';
+import {cerr, checkForUpdate, debug, enableDebug, isDebugEnabled, IUpdateDetails} from './utils';
 import * as os from 'os';
 import meow = require('meow');
 
 checkNodeVersion();
-checkForUpdate().then(() => run()).catch(() => run());
+checkForUpdate()
+    .then(details => run(details))
+    .catch(() => run(null));
 
-function run() {
+function run(updateDetails: IUpdateDetails | null) {
     const cli = meow(`
     Usage:
         $ cplace-asc
@@ -121,7 +123,7 @@ function run() {
         });
 
         // Timeout to ensure flush of stdout
-        assetsCompiler.start().then(() => {
+        assetsCompiler.start(updateDetails).then(() => {
             setTimeout(() => process.exit(0), 200);
         }, () => {
             setTimeout(() => process.exit(1), 200);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,9 @@ import meow = require('meow');
 checkNodeVersion();
 checkForUpdate()
     .then(details => run(details))
-    .catch(() => run(null));
+    .catch(() => run());
 
-function run(updateDetails: IUpdateDetails | null) {
+function run(updateDetails?: IUpdateDetails) {
     const cli = meow(`
     Usage:
         $ cplace-asc

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -72,7 +72,7 @@ export class AssetsCompiler {
         this.projects = this.setupProjects();
     }
 
-    public async start(updateDetails: IUpdateDetails | null): Promise<void> {
+    public async start(updateDetails?: IUpdateDetails): Promise<void> {
         if (!this.projects.size) {
             console.log(cgreen`->`, 'Nothing to do, no plugins detected...');
             return new Promise<void>(resolve => resolve());

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import CplacePlugin from './CplacePlugin';
 import {ExecutorService, Scheduler} from '../executor';
-import {cerr, cgreen, csucc, debug, formatDuration} from '../utils';
+import {cerr, cgreen, csucc, debug, formatDuration, IUpdateDetails} from '../utils';
 
 export interface IAssetsCompilerConfiguration {
     /**
@@ -72,7 +72,7 @@ export class AssetsCompiler {
         this.projects = this.setupProjects();
     }
 
-    public async start(): Promise<void> {
+    public async start(updateDetails: IUpdateDetails | null): Promise<void> {
         if (!this.projects.size) {
             console.log(cgreen`->`, 'Nothing to do, no plugins detected...');
             return new Promise<void>(resolve => resolve());
@@ -104,7 +104,8 @@ export class AssetsCompiler {
         this.executor = new ExecutorService(this.runConfig.maxParallelism);
         this.scheduler = new Scheduler(
             this.executor, this.projects, mainRepoPath,
-            this.runConfig.production, this.runConfig.watchFiles
+            this.runConfig.production, this.runConfig.watchFiles,
+            updateDetails
         );
 
         debug(`(AssetsCompiler) starting scheduler for compilation tasks...`);

--- a/src/utils/check-update.ts
+++ b/src/utils/check-update.ts
@@ -9,7 +9,7 @@ export interface IUpdateDetails {
     availableVersion: Version;
 }
 
-export async function checkForUpdate(): Promise<IUpdateDetails | null> {
+export async function checkForUpdate(): Promise<IUpdateDetails | undefined> {
     process.stdout.write(cgreen`⇢` + ` Checking whether newer version is available... `);
 
     try {
@@ -19,14 +19,14 @@ export async function checkForUpdate(): Promise<IUpdateDetails | null> {
         if (!currentVersion) {
             process.stdout.write(RED_CROSS + '\n');
             debug(`[UpdateCheck] Could not check whether a newer version is available, continuing...`);
-            return null;
+            return undefined;
         }
 
         const remoteVersion = await getRemoteVersionFromRegistry(packageJson.name);
         if (!remoteVersion) {
             process.stdout.write(RED_CROSS + '\n');
             debug(`[UpdateCheck] Could not check whether a newer version is available, continuing...`);
-            return null;
+            return undefined;
         }
 
         process.stdout.write(GREEN_CHECK + '\n');
@@ -42,10 +42,13 @@ export async function checkForUpdate(): Promise<IUpdateDetails | null> {
         debug(`[UpdateCheck] Failed to check whether an update is available, continuing...`);
         debug(e);
     }
-    return null;
+    return undefined;
 }
 
-export function printUpdateDetails(updateDetails: IUpdateDetails): void {
+export function printUpdateDetails(updateDetails?: IUpdateDetails): void {
+    if (!updateDetails) {
+        return;
+    }
     const installed = updateDetails.installedVersion.toString().padStart(8);
     const available = updateDetails.availableVersion.toString().padEnd(8);
     console.log();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "target": "es6",
+    "target": "es2016",
+    "lib": [
+      "es2016",
+      "dom",
+      "es2017.string"
+    ],
     "module": "commonjs",
     "strict": true,
     "noImplicitAny": false,


### PR DESCRIPTION
The update hint will now be displayed *after* every compilation (also during watch):

```
⟹  cplace-asc -c -p cf.cplace.platform         
⇢ Checking whether newer version is available... ✓
Available cpus/cores: 4, rss: 67.17MB, heapTotal: 56.84MB, heapUsed: 21.9MB, external: 0.37MB
✓ [cf.cplace.platform] wrote tsconfig...                 
✓ [cf.cplace.platform] cleaned output directories                                                                                
⟲ [cf.cplace.platform] starting LESS compilation...
⟲ [cf.cplace.platform] starting TypeScript compilation...
⟲ [cf.cplace.platform] starting CSS compression...
✓ [cf.cplace.platform] CSS compression finished (00m01s)
⇢ [cf.cplace.platform] LESS compiled, writing output... (00m02s)
✓ [cf.cplace.platform] LESS finished (00m02s)  
⇢ [cf.cplace.platform] TypeScript compiled, starting bundling... (00m11s)
✓ [cf.cplace.platform] TypeScript finished (00m14s)
                                               
!---------------------------------------------!
! A newer version of @cplace/asc is available !
! >>    0.2.4 -> 0.7.0                        !
! -> Please update to the latest version:     !
!    npm install -g @cplace/asc               !          
!---------------------------------------------!                                                                                  
                                                   

✓ Assets compiled successfully (00m16s)
```

fixes #17