### PR TITLE
Fix NPM resolution for CircleCI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": false,
   "description": "cplace assets compiler",
   "repository": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -100,8 +100,8 @@ export class AssetsCompiler {
             }
         }
 
-        //this.npmResolver = new NPMResolver(mainRepoPath, this.runConfig.watchFiles);
-        //await this.npmResolver.resolve();
+        this.npmResolver = new NPMResolver(mainRepoPath, this.runConfig.watchFiles);
+        await this.npmResolver.resolve();
 
         if (this.runConfig.onlyPreprocessing) {
             console.log();

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -28,6 +28,11 @@ export class NPMResolver {
     }
 
     public async resolve(): Promise<void> {
+        if (!fs.existsSync(this.getPackagePath())) {
+            console.warn(cred`!`, `[NPM] package.json file not found, skipping resolution...`);
+            return Promise.resolve();
+        }
+
         this.checkAndInstall();
 
         if (this.watch) {


### PR DESCRIPTION
On CircleCI during build time on older release the package.json is not present in the target directory where `cplace-asc` is executed. In those cases `cplace-asc` will now just print a warning but continue operation.

This branch has been published as `v0.9.2-beta`