### PR TITLE
Allow definition of webpack externals

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ $ cplace-asc --help
 ### TypeScript
 For each plugin there must be one main entry file `assets/ts/app.ts` which will be used as entry point for bundling. As such any other source file must be imported (transitively) by that file.
 
+If you have additional dependencies to typings files that are placed locally in your plugin you have to include an `extra-types.json` file. This file can have the following strucutre:
+
+```json
+{
+    "declarations": [
+        "relative/path/to/typings/file",
+        "..."
+    ],
+    "externals": {
+        "nameOfImport": "_variableName"
+    }
+}
+```
+
+As you can see you can specify the relative path (taken from the location of the `extra-types.json` file) to any typings definitions (`.d.ts`) file which will then be taken into account by the TypeScript compiler. Furthermore, in order for Webpack to complete the bundling process you most likely will also have to specify the externals that this typings file provides. These are given in the `externals` object. The key must equal to the name of the import in TypeScript (e.g. for `import * as myXs from 'xs'` the key would be `xs`). The value is equal to the global variable name to be resolved by Webpack.
+
 ### LESS
 For each plugin there must be one main entry file: either `assets/less/plugin.less` *or* `assets/less/cplace.less`. The generated CSS file will be called `assets/generated_css/plugin.css` *or* `assets/generated_css/cplace.css` respectively.
 

--- a/src/compiler/AbstractTypescriptCompiler.ts
+++ b/src/compiler/AbstractTypescriptCompiler.ts
@@ -14,6 +14,7 @@ export abstract class AbstractTypescriptCompiler implements ICompiler {
     private static readonly HASH_FILE = 'typings.hash';
 
     protected constructor(protected readonly pluginName: string,
+                protected readonly dependencyPaths: string[],
                 protected readonly assetsPath: string,
                 protected readonly mainRepoDir: string,
                 protected readonly isProduction: boolean,

--- a/src/compiler/CompressCssCompiler.ts
+++ b/src/compiler/CompressCssCompiler.ts
@@ -16,6 +16,7 @@ export class CompressCssCompiler implements ICompiler {
     private readonly pathToEntryFile: string = '';
 
     constructor(private readonly pluginName: string,
+                private readonly dependencyPaths: string[],
                 private readonly assetsPath: string,
                 private readonly mainRepoDir: string,
                 private readonly isProduction: boolean) {

--- a/src/compiler/E2ETypescriptCompiler.ts
+++ b/src/compiler/E2ETypescriptCompiler.ts
@@ -8,9 +8,10 @@ export class E2ETypescriptCompiler extends AbstractTypescriptCompiler {
     public static readonly DEST_DIR = 'generated_e2e';
 
     constructor(pluginName: string,
+                dependencyPaths: string[],
                 assetsPath: string,
                 mainRepoDir: string) {
-        super(pluginName, assetsPath, mainRepoDir, false, 'e2e', E2ETypescriptCompiler.DEST_DIR);
+        super(pluginName, dependencyPaths, assetsPath, mainRepoDir, false, 'e2e', E2ETypescriptCompiler.DEST_DIR);
     }
 
     protected getJobName(): string {

--- a/src/compiler/LessCompiler.ts
+++ b/src/compiler/LessCompiler.ts
@@ -15,6 +15,7 @@ export class LessCompiler implements ICompiler {
     private readonly pathToEntryFile: string = '';
 
     constructor(private readonly pluginName: string,
+                private readonly dependencyPaths: string[],
                 private readonly assetsPath: string,
                 private readonly mainRepoDir: string,
                 private readonly isProduction: boolean) {

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -4,7 +4,14 @@
 
 import {LessCompiler} from './LessCompiler';
 import {CplaceTypescriptCompiler} from './CplaceTypescriptCompiler';
-import {CompilationResult, ICompiler, ICompilerConstructor, ICompileRequest, ICompileResponse, ProcessState} from './interfaces';
+import {
+    CompilationResult,
+    ICompiler,
+    ICompilerConstructor,
+    ICompileRequest,
+    ICompileResponse,
+    ProcessState
+} from './interfaces';
 import {cerr, enableDebug} from '../utils';
 import {CompressCssCompiler} from './CompressCssCompiler';
 import {E2ETypescriptCompiler} from "./E2ETypescriptCompiler";
@@ -66,6 +73,7 @@ if (require.main === module) {
         try {
             compiler = new CompilerConstructor(
                 request.pluginName,
+                request.dependencyPaths,
                 request.assetsPath,
                 request.mainRepoDir,
                 request.isProduction

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -1,5 +1,6 @@
 export interface ICompileRequest {
     pluginName: string;
+    dependencyPaths: string[];
     assetsPath: string;
     mainRepoDir: string;
     isProduction: boolean;
@@ -22,6 +23,7 @@ export interface ICompileResponse {
 
 export interface ICompilerConstructor {
     new(pluginName: string,
+        dependencyPaths: string[],
         assetsPath: string,
         mainRepoDir: string,
         isProduction: boolean): ICompiler;

--- a/src/executor/Scheduler.ts
+++ b/src/executor/Scheduler.ts
@@ -131,6 +131,7 @@ export class Scheduler {
             const plugin = this.getPlugin(nextPlugin);
             const compileRequest: ICompileRequest = {
                 pluginName: plugin.pluginName,
+                dependencyPaths: plugin.dependencies.map(d => this.plugins.get(d)!.pluginDir),
                 assetsPath: plugin.assetsDir,
                 mainRepoDir: this.mainRepoDir,
                 isProduction: this.isProduction,

--- a/src/model/CplacePlugin.ts
+++ b/src/model/CplacePlugin.ts
@@ -51,7 +51,7 @@ export default class CplacePlugin {
         this.dependents = [];
 
         this.repo = path.basename(path.dirname(path.resolve(pluginDir)));
-        this.assetsDir = path.resolve(pluginDir, 'assets');
+        this.assetsDir = CplacePlugin.getAssetsDir(this.pluginDir);
         this.hasTypeScriptAssets = fs.existsSync(path.resolve(this.assetsDir, 'ts', 'app.ts'));
         this.hasTypeScriptE2EAssets = false;
         const e2ePath: string = path.resolve(this.assetsDir, 'e2e');
@@ -61,6 +61,10 @@ export default class CplacePlugin {
 
         this.hasLessAssets = glob.sync(path.join(this.assetsDir, '**', '*.less')).length > 0;
         this.hasCompressCssAssets = fs.existsSync(path.resolve(this.assetsDir, 'css', CompressCssCompiler.ENTRY_FILE_NAME));
+    }
+
+    public static getAssetsDir(pluginDir: string): string {
+        return path.resolve(pluginDir, 'assets');
     }
 
     public static getPluginPathRelativeToRepo(sourceRepo: string, targetPluginName: string, targetRepo: string,


### PR DESCRIPTION
It has been possible to define extra typings for the TypeScript compiler itself, however this has not been sufficient for Webpack to properly bundle the compiled sources.

This PR augments the `extra-types.json` file to also allow definition of Webpack externals.