### PR TITLE
Support new pluginDescriptor instead if IMLs

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "0.11.0-beta",
+  "version": "0.11.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "0.10.0",
+  "version": "0.11.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "0.10.0",
+  "version": "0.11.0-beta",
   "private": false,
   "description": "cplace assets compiler",
   "repository": "https://github.com/collaborationFactory/cplace-asc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "0.11.0-beta",
+  "version": "0.11.0-beta.1",
   "private": false,
   "description": "cplace assets compiler",
   "repository": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -8,6 +8,8 @@ import CplacePlugin from './CplacePlugin';
 import {ExecutorService, Scheduler} from '../executor';
 import {cerr, cgreen, csucc, debug, formatDuration, IUpdateDetails} from '../utils';
 import {NPMResolver} from "./NPMResolver";
+import {ImlParser} from "./ImlParser";
+import {PluginDescriptorParser} from "./PluginDescriptorParser";
 
 export interface IAssetsCompilerConfiguration {
     /**
@@ -225,8 +227,9 @@ export class AssetsCompiler {
     }
 
     private static directoryLooksLikePlugin(pluginPath: string, potentialPluginName: string): boolean {
-        return fs.existsSync(path.join(pluginPath, `${potentialPluginName}.iml`)) // IML file
-            && fs.existsSync(path.join(pluginPath, 'src')); // path to src directory - release-notes will be excluded
+        return (
+            ImlParser.doesImlExist(pluginPath, potentialPluginName) || PluginDescriptorParser.doesPluginDescriptorExist(pluginPath)
+        ) && fs.existsSync(path.join(pluginPath, 'src')); // path to src directory - release-notes will be excluded
     }
 
     private static addProjectDependenciesRecursively(projects: Map<string, CplacePlugin>,

--- a/src/model/DependencyParser.ts
+++ b/src/model/DependencyParser.ts
@@ -40,6 +40,6 @@ class PluginDescriptorDependencyParser implements DependencyParser {
         if (pluginName !== pluginDescriptor.name) {
             throw new Error(`[DependencyParser] Expected plugin name ${pluginName} does not match descriptor plugin name: ${pluginDescriptor.name}`);
         }
-        return [...pluginDescriptor.dependencies];
+        return pluginDescriptor.dependencies ? [...pluginDescriptor.dependencies] : [];
     }
 }

--- a/src/model/DependencyParser.ts
+++ b/src/model/DependencyParser.ts
@@ -40,6 +40,13 @@ class PluginDescriptorDependencyParser implements DependencyParser {
         if (pluginName !== pluginDescriptor.name) {
             throw new Error(`[DependencyParser] Expected plugin name ${pluginName} does not match descriptor plugin name: ${pluginDescriptor.name}`);
         }
-        return pluginDescriptor.dependencies ? [...pluginDescriptor.dependencies] : [];
+
+        const dependencies = pluginDescriptor.dependencies || [];
+        if (excludeTestDependencies) {
+            return [...dependencies];
+        } else {
+            const testDependencies = pluginDescriptor.testDependencies || [];
+            return [...dependencies, ...testDependencies];
+        }
     }
 }

--- a/src/model/DependencyParser.ts
+++ b/src/model/DependencyParser.ts
@@ -1,0 +1,45 @@
+import {PackageVersion} from "./PackageVersion";
+import * as path from "path";
+import {ImlParser} from "./ImlParser";
+import {PluginDescriptorParser} from "./PluginDescriptorParser";
+import {debug} from "../utils";
+
+export interface DependencyParser {
+    getPluginDependencies(pluginDir: string, pluginName: string, excludeTestDependencies: boolean): string[];
+}
+
+export function getDependencyParser(): DependencyParser {
+    if (PackageVersion.get().major < 3) {
+        return new ImlDependencyParser();
+    } else {
+        return new PluginDescriptorDependencyParser();
+    }
+}
+
+class ImlDependencyParser implements DependencyParser {
+    public getPluginDependencies(pluginDir: string, pluginName: string, excludeTestDependencies: boolean): string[] {
+        const pathToIml = path.join(pluginDir, `${pluginName}.iml`);
+        const imlParser = new ImlParser(pathToIml);
+
+        return imlParser.getReferencedModules()
+            .filter(module => {
+                const includeDependency = !excludeTestDependencies || !module.isTestScoped;
+                if (!includeDependency) {
+                    debug(`(DependencyParser) [${pluginName}] excluding test dependency: ${module.moduleName}`);
+                }
+                return includeDependency;
+            })
+            .map(module => module.moduleName);
+    }
+}
+
+class PluginDescriptorDependencyParser implements DependencyParser {
+    public getPluginDependencies(pluginDir: string, pluginName: string, excludeTestDependencies: boolean): string[] {
+        const descriptorParser = new PluginDescriptorParser(pluginDir);
+        const pluginDescriptor = descriptorParser.getPluginDescriptor();
+        if (pluginName !== pluginDescriptor.name) {
+            throw new Error(`[DependencyParser] Expected plugin name ${pluginName} does not match descriptor plugin name: ${pluginDescriptor.name}`);
+        }
+        return [...pluginDescriptor.dependencies];
+    }
+}

--- a/src/model/ImlParser.ts
+++ b/src/model/ImlParser.ts
@@ -11,9 +11,9 @@ export interface IImlModuleDependency {
 export class ImlParser {
     private _module: any;
 
-    constructor(private pathToIml: string) {
-        if (!fs.existsSync(pathToIml)) {
-            throw Error(`IML ${pathToIml} does not exist`);
+    constructor(private readonly pathToIml: string) {
+        if (!fs.existsSync(this.pathToIml)) {
+            throw Error(`IML ${this.pathToIml} does not exist`);
         }
         this.parseFile();
     }

--- a/src/model/ImlParser.ts
+++ b/src/model/ImlParser.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 declare function require(name: string): any;
 
 const fs = require('fs');
@@ -16,6 +18,10 @@ export class ImlParser {
             throw Error(`IML ${this.pathToIml} does not exist`);
         }
         this.parseFile();
+    }
+
+    public static doesImlExist(directory: string, pluginName: string): boolean {
+        return fs.existsSync(path.join(directory, `${pluginName}.iml`));
     }
 
     public getReferencedModules(): IImlModuleDependency[] {

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -18,9 +18,8 @@ import Timeout = NodeJS.Timeout;
 export class NPMResolver {
     private static readonly PACKAGE_LOCK_HASH = 'package-lock.hash';
     private static readonly PACKAGE_LOCK_JSON = 'package-lock.json';
-    private static readonly PACKAGE_JSON = 'package.json';
     private static readonly NODE_MODULES = 'node_modules';
-    private mainRepo: string;
+    private readonly mainRepo: string;
     private readonly hashFilePath: string;
     private watchers: FSWatcher[];
 
@@ -31,8 +30,8 @@ export class NPMResolver {
     }
 
     public async resolve(): Promise<void> {
-        if (!fs.existsSync(this.getPackagePath())) {
-            console.warn(cred`!`, `[NPM] package.json file not found, skipping resolution...`);
+        if (!PackageVersion.getOrNull()) {
+            console.warn(cred`!`, `(NPM) package.json file not found, skipping resolution...`);
             return Promise.resolve();
         }
 
@@ -51,31 +50,8 @@ export class NPMResolver {
         });
     }
 
-    public getPackageVersion(): PackageVersion {
-        const packagePath = this.getPackagePath();
-        if (!fs.existsSync(packagePath)) {
-            console.error(cerr`[NPM] Could not find package.json in repo ${this.mainRepo} - aborting...`);
-            throw Error(cerr`[NPM] Could not find package.json in repo ${this.mainRepo} - aborting...`);
-        }
-
-        const packageJson_String = fs.readFileSync(packagePath, 'utf8');
-        const packageJson = JSON.parse(packageJson_String);
-        const versionString = packageJson.version as string;
-        const versionParts = versionString.split('.');
-        if (versionParts.length !== 3) {
-            console.error(cerr`[NPM] Expected package.json "version" to consist of 3 parts`);
-            throw new Error(`[NPM] Expected package.json "version" to consist of 3 parts`);
-        }
-
-        return {
-            major: parseInt(versionParts[0]),
-            minor: parseInt(versionParts[1]),
-            patch: parseInt(versionParts[2])
-        };
-    }
-
     private shouldResolveNpmModules(): boolean {
-        return this.getPackageVersion().major !== 1;
+        return PackageVersion.get().major !== 1;
     }
 
     private registerWatchers() {
@@ -87,7 +63,7 @@ export class NPMResolver {
                 this.checkAndInstall();
             })
             .on('error', (e) => {
-                console.error(cerr`[NPM] error while watching package-lock.json: ${e}`);
+                console.error(cerr`(NPM) error while watching package-lock.json: ${e}`);
                 packageJsonWatcher.close();
             });
 
@@ -105,7 +81,7 @@ export class NPMResolver {
             debounce && clearTimeout(debounce);
             debounce = setTimeout(() => {
                 if (!fs.existsSync(this.getNodeModulesPath())) {
-                    console.log(cerr`[NPM] node_modules folder has been removed - restart cplace-asc`);
+                    console.log(cerr`(NPM) node_modules folder has been removed - restart cplace-asc`);
                     process.exit();
                 } else {
                     this.checkAndInstall();
@@ -117,7 +93,7 @@ export class NPMResolver {
             .on('unlink', handleEvent)
             .on('unlinkDir', handleEvent)
             .on('error', (e) => {
-                console.error(cerr`[NPM] node_modules watcher failed: ${e}`);
+                console.error(cerr`(NPM) node_modules watcher failed: ${e}`);
                 nodeModulesWatcher.close();
             });
     }
@@ -157,19 +133,19 @@ export class NPMResolver {
                     cwd: this.mainRepo
                 });
             }
-            console.log(cgreen`⇢`, `[NPM] package.json:v1.0.0 -> node_modules checked in`);
+            console.log(cgreen`⇢`, `(NPM) package.json:v1.0.0 -> node_modules checked in`);
             return;
         } else {
-            console.log(cgreen`⇢`, `[NPM] package.json:>v2.0.0 -> checking for npm install`);
+            console.log(cgreen`⇢`, `(NPM) package.json:>v2.0.0 -> checking for npm install`);
         }
 
         if (this.hasNoNodeModules()) {
-            console.log(cgreen`⇢`, `[NPM] node_modules don't exist...`);
+            console.log(cgreen`⇢`, `(NPM) node_modules don't exist...`);
             this.doNpmInstallAndCreateHash();
         } else {
             if (fs.existsSync(this.hashFilePath)) {
                 if (this.packageLockWasUpdated()) {
-                    console.log(cgreen`⇢`, `[NPM] package-lock.json was updated...`);
+                    console.log(cgreen`⇢`, `(NPM) package-lock.json was updated...`);
                     this.doNpmInstallAndCreateHash();
                 }
             } else {
@@ -181,23 +157,23 @@ export class NPMResolver {
     private packageLockWasUpdated(): boolean {
         const oldHash = fs.readFileSync(this.hashFilePath, {encoding: 'utf8'});
         if (oldHash === this.getHash4PackageLock()) {
-            console.log(cgreen`✓`, `[NPM] node_modules are up to date`);
+            console.log(cgreen`✓`, `(NPM) node_modules are up to date`);
             return false;
         }
         return true;
     }
 
     private doNpmInstallAndCreateHash() {
-        console.log(`⟲ [NPM] executing npm install`);
+        console.log(`⟲ (NPM) executing npm install`);
         const result = spawn.sync('npm', ['install'], {
             stdio: [process.stdin, process.stdout, process.stderr],
             cwd: this.mainRepo
         });
         if (result.status !== 0) {
-            console.log(cred`✗`, `[NPM] npm install ran into: ${result.error} and failed`);
-            throw Error(`✗ [NPM] npm install failed...`);
+            console.log(cred`✗`, `(NPM) npm install ran into: ${result.error} and failed`);
+            throw Error(`✗ (NPM) npm install failed...`);
         }
-        console.log(cgreen`⇢`, `[NPM] npm install successful`);
+        console.log(cgreen`⇢`, `(NPM) npm install successful`);
         this.createHashFile();
     }
 
@@ -237,9 +213,5 @@ export class NPMResolver {
 
     private getPackageLockPath(): string {
         return path.resolve(this.mainRepo, NPMResolver.PACKAGE_LOCK_JSON);
-    }
-
-    private getPackagePath(): string {
-        return path.resolve(this.mainRepo, NPMResolver.PACKAGE_JSON);
     }
 }

--- a/src/model/PackageVersion.ts
+++ b/src/model/PackageVersion.ts
@@ -1,20 +1,55 @@
+import * as fs from "fs";
+import {cerr, cwarn} from "../utils";
+import * as path from "path";
+
 export class PackageVersion {
-    private static _version: PackageVersion;
+    private static readonly PACKAGE_JSON = 'package.json';
+
+    private static _version: PackageVersion | null | undefined = undefined;
 
     private constructor(public readonly major: number, public readonly minor: number, public readonly patch: number) {
     }
 
-    public static initialize(major: number, minor: number, patch: number): void {
-        if (PackageVersion._version) {
+    public static initialize(mainRepo: string): PackageVersion | null {
+        if (PackageVersion._version !== undefined) {
             throw new Error(`(PackageVersion) version has already been initialized`);
         }
-        PackageVersion._version = new PackageVersion(major, minor, patch);
+
+        const packagePath = path.resolve(mainRepo, PackageVersion.PACKAGE_JSON);
+        if (!fs.existsSync(packagePath)) {
+            console.warn(cwarn`[NPM] Could not find package.json in repo ${mainRepo}...`);
+            return null;
+        }
+
+        const packageJson_String = fs.readFileSync(packagePath, 'utf8');
+        const packageJson = JSON.parse(packageJson_String);
+        const versionString = packageJson.version as string;
+        const versionParts = versionString.split('.');
+        if (versionParts.length !== 3) {
+            console.error(cerr`[NPM] Expected package.json "version" to consist of 3 parts`);
+            throw new Error(`[NPM] Expected package.json "version" to consist of 3 parts`);
+        }
+
+        PackageVersion._version = new PackageVersion(
+            parseInt(versionParts[0]),
+            parseInt(versionParts[1]),
+            parseInt(versionParts[2])
+        );
+        return PackageVersion._version;
     }
 
-    public static get(): PackageVersion {
-        if (!PackageVersion._version) {
+    public static getOrNull(): PackageVersion | null {
+        if (PackageVersion._version === undefined) {
             throw new Error(`(PackageVersion) version has not yet been initialized`);
         }
         return PackageVersion._version;
+    }
+
+    public static get(): PackageVersion {
+        const version = PackageVersion.getOrNull();
+        if (!version) {
+            throw new Error(`(PackageVersion) version could not be parsed`);
+        }
+        return version;
     }
 }

--- a/src/model/PackageVersion.ts
+++ b/src/model/PackageVersion.ts
@@ -1,0 +1,20 @@
+export class PackageVersion {
+    private static _version: PackageVersion;
+
+    private constructor(public readonly major: number, public readonly minor: number, public readonly patch: number) {
+    }
+
+    public static initialize(major: number, minor: number, patch: number): void {
+        if (PackageVersion._version) {
+            throw new Error(`(PackageVersion) version has already been initialized`);
+        }
+        PackageVersion._version = new PackageVersion(major, minor, patch);
+    }
+
+    public static get(): PackageVersion {
+        if (!PackageVersion._version) {
+            throw new Error(`(PackageVersion) version has not yet been initialized`);
+        }
+        return PackageVersion._version;
+    }
+}

--- a/src/model/PluginDescriptorParser.ts
+++ b/src/model/PluginDescriptorParser.ts
@@ -1,0 +1,37 @@
+import * as path from "path";
+import * as fs from "fs";
+
+export interface PluginDescriptor {
+    /**
+     * Name of the plugin
+     */
+    readonly name: string;
+    /**
+     * List of plugin names this plugin depends on
+     */
+    readonly dependencies: string[];
+}
+
+export class PluginDescriptorParser {
+    public static readonly DESCRIPTOR_FILE_NAME = 'plugin-descriptor.json';
+
+    private readonly pathToDescriptor: string;
+    private readonly descriptor: PluginDescriptor;
+
+    constructor(private pluginDir: string) {
+        this.pathToDescriptor = path.join(pluginDir, PluginDescriptorParser.DESCRIPTOR_FILE_NAME);
+        if (!fs.existsSync(this.pathToDescriptor)) {
+            throw Error(`IML ${this.pathToDescriptor} does not exist`);
+        }
+        this.descriptor = this.parseFile();
+    }
+
+    public getPluginDescriptor(): PluginDescriptor {
+        return this.descriptor;
+    }
+
+    private parseFile(): PluginDescriptor {
+        const content = fs.readFileSync(this.pathToDescriptor, {encoding: 'utf8'});
+        return JSON.parse(content) as PluginDescriptor;
+    }
+}

--- a/src/model/PluginDescriptorParser.ts
+++ b/src/model/PluginDescriptorParser.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
+import {cerr} from "../utils";
 
 export interface PluginDescriptor {
     /**
@@ -9,11 +10,11 @@ export interface PluginDescriptor {
     /**
      * List of plugin names this plugin depends on
      */
-    readonly dependencies: string[];
+    readonly dependencies?: string[];
 }
 
 export class PluginDescriptorParser {
-    public static readonly DESCRIPTOR_FILE_NAME = 'plugin-descriptor.json';
+    public static readonly DESCRIPTOR_FILE_NAME = 'pluginDescriptor.json';
 
     private readonly pathToDescriptor: string;
     private readonly descriptor: PluginDescriptor;
@@ -21,7 +22,8 @@ export class PluginDescriptorParser {
     constructor(private pluginDir: string) {
         this.pathToDescriptor = path.join(pluginDir, PluginDescriptorParser.DESCRIPTOR_FILE_NAME);
         if (!fs.existsSync(this.pathToDescriptor)) {
-            throw Error(`IML ${this.pathToDescriptor} does not exist`);
+            console.error(cerr`(PluginDescriptor) Failed to find plugin descriptor for ${path.basename(pluginDir)}`);
+            throw Error(`PluginDescriptor ${this.pathToDescriptor} does not exist`);
         }
         this.descriptor = this.parseFile();
     }

--- a/src/model/PluginDescriptorParser.ts
+++ b/src/model/PluginDescriptorParser.ts
@@ -8,9 +8,13 @@ export interface PluginDescriptor {
      */
     readonly name: string;
     /**
-     * List of plugin names this plugin depends on
+     * List of plugin names this plugin depends on for production
      */
     readonly dependencies?: string[];
+    /**
+     * List of plugin names this plugin depends on for production
+     */
+    readonly testDependencies?: string[];
 }
 
 export class PluginDescriptorParser {

--- a/src/model/PluginDescriptorParser.ts
+++ b/src/model/PluginDescriptorParser.ts
@@ -24,12 +24,20 @@ export class PluginDescriptorParser {
     private readonly descriptor: PluginDescriptor;
 
     constructor(private pluginDir: string) {
-        this.pathToDescriptor = path.join(pluginDir, PluginDescriptorParser.DESCRIPTOR_FILE_NAME);
+        this.pathToDescriptor = PluginDescriptorParser.getPathToDescriptor(pluginDir);
         if (!fs.existsSync(this.pathToDescriptor)) {
             console.error(cerr`(PluginDescriptor) Failed to find plugin descriptor for ${path.basename(pluginDir)}`);
             throw Error(`PluginDescriptor ${this.pathToDescriptor} does not exist`);
         }
         this.descriptor = this.parseFile();
+    }
+
+    public static getPathToDescriptor(pluginDir) {
+        return path.join(pluginDir, PluginDescriptorParser.DESCRIPTOR_FILE_NAME);
+    }
+
+    public static doesPluginDescriptorExist(pluginDir: string): boolean {
+        return fs.existsSync(this.getPathToDescriptor(pluginDir));
     }
 
     public getPluginDescriptor(): PluginDescriptor {


### PR DESCRIPTION
This solves #34 where we introduce support for a new `pluginDescriptor.json` file auto-generated by the Gradle build instead of relying on the IML module descriptors.