### PR TITLE
Revert to default package version 1.0.0 if no package.json found

### DIFF
--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -30,11 +30,6 @@ export class NPMResolver {
     }
 
     public async resolve(): Promise<void> {
-        if (!PackageVersion.getOrNull()) {
-            console.warn(cred`!`, `(NPM) package.json file not found, skipping resolution...`);
-            return Promise.resolve();
-        }
-
         this.checkAndInstall();
 
         if (this.watch) {

--- a/src/model/PackageVersion.ts
+++ b/src/model/PackageVersion.ts
@@ -5,12 +5,12 @@ import * as path from "path";
 export class PackageVersion {
     private static readonly PACKAGE_JSON = 'package.json';
 
-    private static _version: PackageVersion | null | undefined = undefined;
+    private static _version: PackageVersion | undefined = undefined;
 
     private constructor(public readonly major: number, public readonly minor: number, public readonly patch: number) {
     }
 
-    public static initialize(mainRepo: string): PackageVersion | null {
+    public static initialize(mainRepo: string): PackageVersion {
         if (PackageVersion._version !== undefined) {
             throw new Error(`(PackageVersion) version has already been initialized`);
         }
@@ -39,18 +39,10 @@ export class PackageVersion {
         return PackageVersion._version;
     }
 
-    public static getOrNull(): PackageVersion | null {
+    public static get(): PackageVersion {
         if (PackageVersion._version === undefined) {
             throw new Error(`(PackageVersion) version has not yet been initialized`);
         }
         return PackageVersion._version;
-    }
-
-    public static get(): PackageVersion {
-        const version = PackageVersion.getOrNull();
-        if (!version) {
-            throw new Error(`(PackageVersion) version could not be parsed`);
-        }
-        return version;
     }
 }

--- a/src/model/PackageVersion.ts
+++ b/src/model/PackageVersion.ts
@@ -18,23 +18,24 @@ export class PackageVersion {
         const packagePath = path.resolve(mainRepo, PackageVersion.PACKAGE_JSON);
         if (!fs.existsSync(packagePath)) {
             console.warn(cwarn`[NPM] Could not find package.json in repo ${mainRepo}...`);
-            return null;
-        }
+            console.warn(cwarn`[NPM] -> Assuming version 1.0.0`);
+            PackageVersion._version = new PackageVersion(1, 0, 0);
+        } else {
+            const packageJson_String = fs.readFileSync(packagePath, 'utf8');
+            const packageJson = JSON.parse(packageJson_String);
+            const versionString = packageJson.version as string;
+            const versionParts = versionString.split('.');
+            if (versionParts.length !== 3) {
+                console.error(cerr`[NPM] Expected package.json "version" to consist of 3 parts`);
+                throw new Error(`[NPM] Expected package.json "version" to consist of 3 parts`);
+            }
 
-        const packageJson_String = fs.readFileSync(packagePath, 'utf8');
-        const packageJson = JSON.parse(packageJson_String);
-        const versionString = packageJson.version as string;
-        const versionParts = versionString.split('.');
-        if (versionParts.length !== 3) {
-            console.error(cerr`[NPM] Expected package.json "version" to consist of 3 parts`);
-            throw new Error(`[NPM] Expected package.json "version" to consist of 3 parts`);
+            PackageVersion._version = new PackageVersion(
+                parseInt(versionParts[0]),
+                parseInt(versionParts[1]),
+                parseInt(versionParts[2])
+            );
         }
-
-        PackageVersion._version = new PackageVersion(
-            parseInt(versionParts[0]),
-            parseInt(versionParts[1]),
-            parseInt(versionParts[2])
-        );
         return PackageVersion._version;
     }
 


### PR DESCRIPTION
Fixes #36 

Before release 4.57 the `package.json` file has not been copied during the build process. To make it fully backwards compatible without adding a change to the build.xml in all versions prior this is the fix.