### PR TITLE
PFM-ISSUE-5620 added support of npm install --only=prod

### DIFF
--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -114,7 +114,7 @@ export class AssetsCompiler {
             }
         }
 
-        this.npmResolver = new NPMResolver(mainRepoPath, this.runConfig.watchFiles);
+        this.npmResolver = new NPMResolver(mainRepoPath, this.runConfig.watchFiles, this.runConfig.production);
         await this.npmResolver.resolve();
 
         if (this.runConfig.onlyPreprocessing) {

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -218,7 +218,9 @@ export class AssetsCompiler {
                 project.generateTsConfig(p => projects.get(p), this.runConfig.production, this.runConfig.localOnly);
             }
             if (project.hasTypeScriptE2EAssets) {
+                if (!this.runConfig.production) {
                     project.generateTsE2EConfig(p => projects.get(p), false, this.runConfig.localOnly)
+                }
             }
         });
 

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -218,9 +218,7 @@ export class AssetsCompiler {
                 project.generateTsConfig(p => projects.get(p), this.runConfig.production, this.runConfig.localOnly);
             }
             if (project.hasTypeScriptE2EAssets) {
-                if (!this.runConfig.production) {
                     project.generateTsE2EConfig(p => projects.get(p), false, this.runConfig.localOnly)
-                }
             }
         });
 

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -159,7 +159,7 @@ export class NPMResolver {
     }
 
     private doNpmInstallAndCreateHash() {
-        let result
+        let result;
         if (this.isProduction) {
             console.log(`⟲ (NPM) executing npm install in production mode '--only=prod'`);
             result = spawn.sync('npm', ['install', '--only=prod'], {

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -23,7 +23,7 @@ export class NPMResolver {
     private readonly hashFilePath: string;
     private watchers: FSWatcher[];
 
-    constructor(mainRepo: string, private watch: boolean) {
+    constructor(mainRepo: string, private watch: boolean, private isProduction: boolean) {
         this.mainRepo = mainRepo;
         this.hashFilePath = this.getHashFilePath();
         this.watchers = [];
@@ -159,11 +159,20 @@ export class NPMResolver {
     }
 
     private doNpmInstallAndCreateHash() {
-        console.log(`⟲ (NPM) executing npm install`);
-        const result = spawn.sync('npm', ['install'], {
-            stdio: [process.stdin, process.stdout, process.stderr],
-            cwd: this.mainRepo
-        });
+        let result
+        if (this.isProduction) {
+            console.log(`⟲ (NPM) executing npm install in production mode '--only=prod'`);
+            result = spawn.sync('npm', ['install', '--only=prod'], {
+                stdio: [process.stdin, process.stdout, process.stderr],
+                cwd: this.mainRepo
+            });
+        } else {
+            console.log(`⟲ (NPM) executing npm install`);
+            result = spawn.sync('npm', ['install'], {
+                stdio: [process.stdin, process.stdout, process.stderr],
+                cwd: this.mainRepo
+            });
+        }
         if (result.status !== 0) {
             console.log(cred`✗`, `(NPM) npm install ran into: ${result.error} and failed`);
             throw Error(`✗ (NPM) npm install failed...`);


### PR DESCRIPTION
When wdio-image-comparison-service was added to DevDependencies in cplace main Repository the dockerized cloud builds crashed. The crash is due to alpine images that do not provide necessary system libraries. As cloud builds are production builds we aim for not installing Dev-Dependencies in production builds.

[PFM-ISSUE-5620](https://base.cplace.io/pages/yuz4s0b8ogllnnsdbb7pxar3l/PFM-ISSUE-5620-Add-support-of-Production-flag-for-NPM-install)