### PR TITLE
PFM-ISSUE-6822 - Fix cplace-asc symlink on Windows

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "cplace assets compiler",
   "repository": "https://github.com/collaborationFactory/cplace-asc",
   "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -74,7 +74,29 @@ export class NPMResolver {
         }
         console.log(cgreen`✓`, `[${pluginName}] (NPM) dependencies successfully installed`);
         NPMResolver.createPluginHashFile(assetsPath);
+        NPMResolver.removePluginSymlinks(pluginName, assetsPath);
         return true;
+    }
+
+    /**
+     * Removes symlinks inside plugin node_modules folder
+     * @param pluginName Plugin name
+     * @param assetsPath Assets folder path
+     * @private
+     */
+    private static removePluginSymlinks(pluginName: string, assetsPath: string): void {
+        const isWindows = process.platform === 'win32';
+        if (isWindows) {
+            console.log(`⟲ [${pluginName}] (NPM) removing symlinks...`);
+            const nodeModulesPath = path.resolve(assetsPath, 'node_modules');
+            fs.readdirSync(nodeModulesPath).forEach(dir => {
+                const dirPath = path.resolve(nodeModulesPath, dir);
+                if (fs.lstatSync(dirPath).isSymbolicLink()) {
+                    rimraf.sync(dirPath);
+                }
+            });
+            console.log(cgreen`✓`, `[${pluginName}] (NPM) symlinks removed`);
+        }
     }
 
     /**


### PR DESCRIPTION
resolves [PFM-ISSUE-6822](https://base.cplace.io/pages/lz0dvlo6eik99v8cqvjl3zg67/PFM-ISSUE-6822-Fix-cplace-asc-symlink-on-Windows#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)

### How to test
- use `npm link` command in cplace-asc repo
- remove the node_modules folder from the affected plugin assets
- run `cplace-asc` in target repository