### PR TITLE
PFM-ISSUE-6660 - Handle LESS escaping

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3746,9 +3746,9 @@
       }
     },
     "generic-pool": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.7.2.tgz",
-      "integrity": "sha512-Ec7D4KySmEtIdJBNRVS8jus84ejNAvYG7KaLsXMhIs4AVQ2RuXSjMtmpskTKDT0y6TFSPjo4H+cCmLKUb+vDzg=="
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.7.8.tgz",
+      "integrity": "sha512-Pz93INFSbhjEROVbM91rurD05G+Kx8833rG+lVU57mznEBpzkc1f5/g+d511a1Yf8dbAEsm7DDA3QLytMFbiGA=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/asc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "cplace assets compiler",
   "repository": "https://github.com/collaborationFactory/cplace-asc",
   "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/compiler/LessCompiler.ts
+++ b/src/compiler/LessCompiler.ts
@@ -8,6 +8,7 @@ import {CompilationResult, ICompiler} from './interfaces';
 import {cerr, cgreen, cwarn, formatDuration, GREEN_CHECK} from '../utils';
 import {CompressCssCompiler} from './CompressCssCompiler';
 import Options = Less.Options;
+import {lessPlugins} from "../model/LessPlugins";
 
 export class LessCompiler implements ICompiler {
     private static readonly LESS_SOURCES_DIR = 'less';
@@ -47,7 +48,8 @@ export class LessCompiler implements ICompiler {
         console.log(`⟲ [${this.pluginName}] starting LESS compilation...`);
         return new Promise<CompilationResult>((resolve, reject) => {
             const lesscOptions: Options = {
-                filename: path.resolve(entryFile)
+                filename: path.resolve(entryFile),
+                plugins: lessPlugins(this.pluginName)
             };
             if (!this.isProduction) {
                 lesscOptions.sourceMap = {
@@ -67,11 +69,6 @@ export class LessCompiler implements ICompiler {
                         throw Error(`[${this.pluginName}] LESS compilation failed`);
                     })
                     .then((output: any) => {
-
-                        const improperLessEscaping = this.checkImproperLessEscaping(output.css);
-                        if (improperLessEscaping) {
-                            console.log(cwarn`⇢ [${this.pluginName}] LESS not properly escaped:\n${improperLessEscaping}`);
-                        }
 
                         let end = new Date().getTime();
                         console.log(cgreen`⇢`, `[${this.pluginName}] LESS compiled, writing output... (${formatDuration(end - start)})`);
@@ -117,25 +114,6 @@ export class LessCompiler implements ICompiler {
                 }
             });
         })
-    }
-
-    /**
-     * Checks improper LESS escaping
-     * @param cssOutput CSS string output
-     * @private
-     */
-    private checkImproperLessEscaping(cssOutput: string): string | undefined {
-        const cssOutputArray = cssOutput.split('\n');
-        const foundImproperLessEscaping = cssOutputArray.reduce((acc: string[], val: string) => {
-            if (val.includes('calc(') && !val.includes('~') && !val.includes('--')) {
-                const spacer = '  ';
-                acc.push(spacer.concat(val.trim()));
-            }
-            return acc;
-        }, []);
-        if (foundImproperLessEscaping && foundImproperLessEscaping.length) {
-            return foundImproperLessEscaping.join('\n');
-        }
     }
 
     private parseLESSVariablesToCSS(lessContent: string, lessVariables: {[key: string]: any} = {}): string {

--- a/src/model/LessEscapePlugin.ts
+++ b/src/model/LessEscapePlugin.ts
@@ -19,7 +19,7 @@ function checkImproperLessEscaping(cssOutput: string): string | undefined {
     }
 }
 
-let processedFiles: string[] = [];
+let processedFiles: Set<string> = new Set<string>();
 
 /**
  * Processes LESS data and warns if there is an improper LESS escaping
@@ -29,14 +29,18 @@ export function lessEscapePlugin(pluginName: string) {
     return {
         process: (src, extra) => {
             const improperLessEscaping = checkImproperLessEscaping(src);
-            if (improperLessEscaping && !processedFiles.includes(extra.fileInfo.filename)) {
-                const spacer = '  ';
-                console.log(cwarn`⇢ [${pluginName}] LESS not properly escaped in ${extra.fileInfo.filename}:\n${improperLessEscaping}\n\n${spacer}Please escape LESS the following way:\n${spacer}width: ~"calc(100% - 200px)"; or width: ~"calc(100vw - " @yourVariable ~")";\n`);
-                processedFiles.push(extra.fileInfo.filename);
+            if (improperLessEscaping && !processedFiles.has(extra.fileInfo.filename)) {
+                const spacer = ' ';
+                console.log(
+                    cwarn`⇢ [${pluginName}] LESS not properly escaped in ${extra.fileInfo.filename}:`,
+                    cwarn`\n${improperLessEscaping}\n\n`,
+                    cwarn`${spacer}Please escape LESS the following way:\n`,
+                    cwarn`${spacer}width: ~"calc(100% - 200px)"; or width: ~"calc(100vw - " @yourVariable ~")";\n`
+                );
+                processedFiles.add(extra.fileInfo.filename);
             } else {
-                const foundFile = processedFiles.indexOf(extra.fileInfo.filename);
-                if (foundFile !== -1) {
-                    processedFiles.splice(foundFile, 1);
+                if (processedFiles.has(extra.fileInfo.filename)) {
+                    processedFiles.delete(extra.fileInfo.filename);
                 }
             }
             return src;

--- a/src/model/LessEscapePlugin.ts
+++ b/src/model/LessEscapePlugin.ts
@@ -28,13 +28,16 @@ let processedFiles: string[] = [];
 export function lessEscapePlugin(pluginName: string) {
     return {
         process: (src, extra) => {
-            if (!processedFiles.includes(extra.fileInfo.filename)) {
-                const improperLessEscaping = checkImproperLessEscaping(src);
-                if (improperLessEscaping) {
-                    const spacer = '  ';
-                    console.log(cwarn`⇢ [${pluginName}] LESS not properly escaped in ${extra.fileInfo.filename}:\n${improperLessEscaping}\n\n${spacer}Please escape LESS the following way:\n${spacer}width: ~"calc(100% - 200px)"; or width: ~"calc(100vw - " @yourVariable ~")";\n`);
-                }
+            const improperLessEscaping = checkImproperLessEscaping(src);
+            if (improperLessEscaping && !processedFiles.includes(extra.fileInfo.filename)) {
+                const spacer = '  ';
+                console.log(cwarn`⇢ [${pluginName}] LESS not properly escaped in ${extra.fileInfo.filename}:\n${improperLessEscaping}\n\n${spacer}Please escape LESS the following way:\n${spacer}width: ~"calc(100% - 200px)"; or width: ~"calc(100vw - " @yourVariable ~")";\n`);
                 processedFiles.push(extra.fileInfo.filename);
+            } else {
+                const foundFile = processedFiles.indexOf(extra.fileInfo.filename);
+                if (foundFile !== -1) {
+                    processedFiles.splice(foundFile, 1);
+                }
             }
             return src;
         }

--- a/src/model/LessEscapePlugin.ts
+++ b/src/model/LessEscapePlugin.ts
@@ -19,7 +19,7 @@ function checkImproperLessEscaping(cssOutput: string): string | undefined {
     }
 }
 
-let processedFiles: Set<string> = new Set<string>();
+let improperLessEscapedFiles: Set<string> = new Set<string>();
 
 /**
  * Processes LESS data and warns if there is an improper LESS escaping
@@ -29,7 +29,7 @@ export function lessEscapePlugin(pluginName: string) {
     return {
         process: (src, extra) => {
             const improperLessEscaping = checkImproperLessEscaping(src);
-            if (improperLessEscaping && !processedFiles.has(extra.fileInfo.filename)) {
+            if (improperLessEscaping && !improperLessEscapedFiles.has(extra.fileInfo.filename)) {
                 const spacer = ' ';
                 console.log(
                     cwarn`⇢ [${pluginName}] LESS not properly escaped in ${extra.fileInfo.filename}:`,
@@ -37,10 +37,11 @@ export function lessEscapePlugin(pluginName: string) {
                     cwarn`${spacer}Please escape LESS the following way:\n`,
                     cwarn`${spacer}width: ~"calc(100% - 200px)"; or width: ~"calc(100vw - " @yourVariable ~")";\n`
                 );
-                processedFiles.add(extra.fileInfo.filename);
+                improperLessEscapedFiles.add(extra.fileInfo.filename);
             } else {
-                if (processedFiles.has(extra.fileInfo.filename)) {
-                    processedFiles.delete(extra.fileInfo.filename);
+                // This is needed to avoid having warnings for the already checked files (watch)
+                if (improperLessEscapedFiles.has(extra.fileInfo.filename)) {
+                    improperLessEscapedFiles.delete(extra.fileInfo.filename);
                 }
             }
             return src;

--- a/src/model/LessEscapePlugin.ts
+++ b/src/model/LessEscapePlugin.ts
@@ -1,0 +1,42 @@
+import {cwarn} from "../utils";
+
+/**
+ * Checks improper LESS escaping
+ * @param cssOutput CSS string output
+ * @private
+ */
+function checkImproperLessEscaping(cssOutput: string): string | undefined {
+    const cssOutputArray = cssOutput.split('\n');
+    const foundImproperLessEscaping = cssOutputArray.reduce((acc: string[], val: string) => {
+        if (val.includes('calc(') && !val.includes('~') && !val.includes('--')) {
+            const spacer = '  ';
+            acc.push(spacer.concat(val.trim()));
+        }
+        return acc;
+    }, []);
+    if (foundImproperLessEscaping && foundImproperLessEscaping.length) {
+        return foundImproperLessEscaping.join('\n');
+    }
+}
+
+let processedFiles: string[] = [];
+
+/**
+ * Processes LESS data and warns if there is an improper LESS escaping
+ * @param pluginName Plugin name
+ */
+export function lessEscapePlugin(pluginName: string) {
+    return {
+        process: (src, extra) => {
+            if (!processedFiles.includes(extra.fileInfo.filename)) {
+                const improperLessEscaping = checkImproperLessEscaping(src);
+                if (improperLessEscaping) {
+                    const spacer = '  ';
+                    console.log(cwarn`⇢ [${pluginName}] LESS not properly escaped in ${extra.fileInfo.filename}:\n${improperLessEscaping}\n\n${spacer}Please escape LESS the following way:\n${spacer}width: ~"calc(100% - 200px)"; or width: ~"calc(100vw - " @yourVariable ~")";\n`);
+                }
+                processedFiles.push(extra.fileInfo.filename);
+            }
+            return src;
+        }
+    }
+}

--- a/src/model/LessPlugins.ts
+++ b/src/model/LessPlugins.ts
@@ -1,0 +1,16 @@
+import {lessEscapePlugin} from "./LessEscapePlugin";
+
+/**
+ * Exports all the less plugins
+ * @param pluginName Plugin name
+ */
+export function lessPlugins(pluginName: string) {
+    return [
+        {
+            install: (less, pluginManager) => {
+                pluginManager.addPreProcessor(lessEscapePlugin(pluginName), 2000)
+            },
+            minVersion: [2, 7, 1]
+        }
+    ];
+}


### PR DESCRIPTION
resolves [PFM-ISSUE-6660](https://base.cplace.io/pages/g4eu5s15zme2c5p54jb3rmdat/PFM-ISSUE-6660-Handle-LESS-escaping#/__8jj9zuc561yf9hivrckouo7nl/fe2.0/cf-cplace-platform/0.1.0/)

### NOTE
- to avoid cplace to stop working, only a warning will be displayed. Error will not be thrown.
- warnings in the main repository are fixed with this [PR](https://github.com/collaborationFactory/cplace/pull/4830)

### How to test
- run `npm link` in the cplace-asc repository
- run `cplace-asc` in the cplace repository

#### Expected result

![Screen Shot 2021-05-20 at 15 19 54](https://user-images.githubusercontent.com/16098085/118985617-e1c90e80-b97e-11eb-8d3f-be329efe98a8.png)


