### PR TITLE
PFM-ISSUE-9992 - Force the cplace-asc to install the latest version of the npm tag

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -92,7 +92,7 @@ export class NPMResolver {
         const oldCwd = process.cwd();
         process.chdir(assetsPath);
         console.log(`⟲ [${pluginName}] (NPM) installing dependencies...`);
-        const res = spawn.sync('npm', ['install', '--no-save']);
+        const res = spawn.sync('npm', ['install']);
         if (res.status !== 0) {
             debug(
                 `[${pluginName}] (NPM) installing dependencies failed with error ${res.stderr}`


### PR DESCRIPTION
Resolves [PFM-ISSUE-9992](https://base.cplace.io/pages/mmkblylrrx5ezdjts4uz7parp/PFM-ISSUE-9992-Force-the-cplace-asc-to-install-the-latest-version-of-the-npm-tag#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)
