### PR TITLE
Log error if start of assets-compiler fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,11 @@ function run(updateDetails?: IUpdateDetails) {
             () => {
                 setTimeout(() => process.exit(0), 200);
             },
-            () => {
+            (error) => {
+                console.error(cerr`Failed to start assets compiler: ${error.message}`);
+                if (isDebugEnabled()) {
+                    console.error(error);
+                }
                 setTimeout(() => process.exit(1), 200);
             }
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,10 +191,11 @@ function run(updateDetails?: IUpdateDetails) {
             () => {
                 setTimeout(() => process.exit(0), 200);
             },
-            (error) => {
-                console.error(cerr`Failed to start assets compiler: ${error.message}`);
+            (reason: any) => {
+                const message = reason instanceof Error ? reason.message : reason;
+                console.error(cerr`Failed to start assets compiler: ${message}`);
                 if (isDebugEnabled()) {
-                    console.error(error);
+                    console.error(reason);
                 }
                 setTimeout(() => process.exit(1), 200);
             }


### PR DESCRIPTION
Improves the error output when the start of the assets compiler fails.
