### PR TITLE
PFM-ISSUE-11114: Combine javascript in cplace-asc fails when combine file is empty

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.12",
+    "version": "1.2.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.12",
+    "version": "1.2.13",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/executor/Scheduler.ts
+++ b/src/executor/Scheduler.ts
@@ -78,12 +78,12 @@ export class Scheduler {
         private readonly watchFiles: boolean,
         private readonly updateDetails?: IUpdateDetails
     ) {
+        this.vendorJobs = this.createVendorJobTracker();
         this.tsJobs = this.createTsJobTracker();
         this.tsE2EJobs = this.createTsE2EJobTracker();
         this.lessJobs = this.createLessJobTracker();
         this.openAPIYamlJobs = this.createOpenAPIYamlJobTracker();
         this.compressCssJobs = this.createCompressCssJobTracker();
-        this.vendorJobs = this.createVendorJobTracker();
         this.combineJsJobs = this.createCombineJsJobTracker();
     }
 
@@ -350,7 +350,7 @@ export class Scheduler {
                         plugin.pluginDescriptor.dependencies
                     ),
                     this.filterTypeScriptPlugins(plugin.dependents),
-                    []
+                    [this.vendorJobs.isJobDone.bind(this.vendorJobs)]
                 )
         );
         return new JobTracker(jobs);


### PR DESCRIPTION
Resolves [PFM-ISSUE-11114](https://base.cplace.io/pages/y7o2og1sa3rjrqw212q5dv2gx/PFM-ISSUE-11114-Combine-javascript-in-cplace-asc-fails-when-combine-file-is-empty)

**Checklist:**
- [x] Version updated (if applicable)
- [x] Code formatted
### Release a version (if necessary) after merging to master

