### PR TITLE
PFM-ISSUE-12143 accept node 12 in cplace asc for releases <= 5.18

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.19",
+    "version": "1.2.20",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.19",
+    "version": "1.2.20",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ function checkNodeVersion(): void {
     );
     const nodeVersionUtils = new NodeVersionUtils();
 
-    if (cplaceVersion.major <= 5 && cplaceVersion.minor <= 12) {
+    if (cplaceVersion.major <= 5 && cplaceVersion.minor <= 18) {
         console.log(
             `⟲ cplaceVersion ${CplaceVersion.toString()} is less or equal to 5.12.0 -> assuming node version is correct`
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ function checkNodeVersion(): void {
 
     if (cplaceVersion.major <= 5 && cplaceVersion.minor <= 18) {
         console.log(
-            `⟲ cplaceVersion ${CplaceVersion.toString()} is less or equal to 5.12.0 -> assuming node version is correct`
+            `⟲ cplaceVersion ${CplaceVersion.toString()} is less or equal to 5.18.0 -> assuming node version is correct`
         );
         return;
     }


### PR DESCRIPTION
Resolves [PFM-ISSUE-12143](https://base.cplace.io/pages/8nu9dbnzgpg43jb3icrn4zmzp/PFM-ISSUE-12143-accept-node-12-in-cplacee-asc-for-releases-5.18#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)

**Checklist:**
- [x] Version updated (if applicable)
- [x] Tests added (if applicable)
- [x] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use 