### PR TITLE
PFM-ISSUE-12204 - Stop @cplace/asc in case @cplace/asc-local should be used

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.20",
+    "version": "1.2.21",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.20",
+    "version": "1.2.21",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -9,8 +9,8 @@ import { ExecutorService, Scheduler } from '../executor';
 import {
     cerr,
     cgreen,
+    cred,
     csucc,
-    cwarn,
     debug,
     formatDuration,
     IUpdateDetails,
@@ -18,8 +18,8 @@ import {
 import { NPMResolver } from './NPMResolver';
 import { ImlParser } from './ImlParser';
 import { isFileTracked } from './utils';
-import rimraf = require('rimraf');
 import { CplaceVersion } from './CplaceVersion';
+import rimraf = require('rimraf');
 
 export interface IAssetsCompilerConfiguration {
     /**
@@ -111,9 +111,11 @@ export class AssetsCompiler {
     ) {
         console.log(`⟲ Starting the main process with pid ${process.pid}`);
         if (AssetsCompiler.shouldUseAscLocal()) {
-            console.warn(
-                cwarn`Starting from the cplace release 23.2 you should be using @cplace/asc-local instead of @cplace/asc!`
+            console.error(
+                cred`✗`,
+                `Starting from the cplace release 23.2 you should be using @cplace/asc-local instead of @cplace/asc!`
             );
+            throw Error(`cplace-asc won't start! Check the error above!`);
         }
         this.repositoryName = path.basename(repositoryDir);
         this.projects = this.setupProjects();
@@ -121,11 +123,9 @@ export class AssetsCompiler {
 
     private static shouldUseAscLocal(): boolean {
         const version = CplaceVersion.get();
-        const isAtLeast23_2 =
-            (version.major === 23 && version.minor >= 2) || version.major > 23;
-        const is23_1Snapshot =
-            version.major === 23 && version.minor === 1 && version.snapshot;
-        return isAtLeast23_2 || is23_1Snapshot;
+        return (
+            (version.major === 23 && version.minor >= 2) || version.major > 23
+        );
     }
 
     public async start(updateDetails?: IUpdateDetails): Promise<void> {


### PR DESCRIPTION
Resolves [PFM-ISSUE-12204](https://base.cplace.io/pages/n2bg0ibxrchivkb6a25ps7bmh/PFM-ISSUE-12204-Stop-cplace-asc-in-case-cplace-asc-local-should-be-used#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)

**Checklist:**
- [x] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [x] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [x] Milestone added
- [x] PR labels added
