### PR TITLE
PFM-ISSUE-12691: Don't delete package.json file in the assets folder

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.22",
+    "version": "1.2.23",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.22",
+    "version": "1.2.23",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -153,16 +153,6 @@ export class AssetsCompiler {
                     await plugin.cleanGeneratedOutput();
                 }
             }
-
-            debug(`(AssetsCompiler) cleaning generated package.json file...`);
-            if (
-                !isFileTracked(this.repositoryDir, path.resolve('package.json'))
-            ) {
-                rimraf.sync(path.resolve(this.repositoryDir, 'package.json'));
-                rimraf.sync(
-                    path.resolve(this.repositoryDir, 'package-lock.json')
-                );
-            }
         }
 
         if (this.runConfig.packagejson) {

--- a/src/model/CplacePlugin.ts
+++ b/src/model/CplacePlugin.ts
@@ -273,23 +273,6 @@ export default class CplacePlugin {
             );
             promises.push(this.removeDir(generatedDir));
         }
-        if (
-            !isFileTracked(
-                this.pluginDir,
-                path.resolve(this.pluginDir, 'assets', 'package.json')
-            )
-        ) {
-            promises.push(
-                this.removeDir(
-                    path.resolve(this.pluginDir, 'assets', 'package.json')
-                )
-            );
-            promises.push(
-                this.removeDir(
-                    path.resolve(this.pluginDir, 'assets', 'package-lock.json')
-                )
-            );
-        }
         await Promise.all(promises);
 
         if (promises.length) {


### PR DESCRIPTION
Resolves [PFM-ISSUE-12691](https://base.cplace.io/pages/7qiglhn6hlw2qur66u2vji9v4/PFM-ISSUE-12691-Don-t-delete-package.json-file-in-the-assets-folder)

**Checklist:**
- [x] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [x] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [x] Milestone added
- [x] PR labels added
