### PR TITLE
PFM-ISSUE-24479: use version calculation of the gradle plugin - legacy-asc

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.24",
+    "version": "1.2.25",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc",
-    "version": "1.2.24",
+    "version": "1.2.25",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,6 @@ import { NodeVersionUtils } from './utils/NodeUtils';
 import * as fs from 'fs';
 import meow = require('meow');
 
-const cplaceVersion: CplaceVersion = CplaceVersion.initialize(process.cwd());
-checkNodeVersion();
 checkForUpdate()
     .then((details) => run(details))
     .catch(() => run());
@@ -51,6 +49,7 @@ function run(updateDetails?: IUpdateDetails) {
         --withYaml, -y          Generates TypeScript files from the OpenAPI YAML specification
         --verbose, -v           Enable verbose logging
         --production, -P        Enable production mode (ignores test dependencies and E2E)
+        --cplaceversion, -V     Explicitly specify the current cplace version
 
 `,
         {
@@ -110,9 +109,17 @@ function run(updateDetails?: IUpdateDetails) {
                     alias: 'P',
                     default: false,
                 },
+                cplaceversion: {
+                    type: 'string',
+                    alias: 'V',
+                    default: '',
+                },
             },
         }
     );
+
+    CplaceVersion.initialize(process.cwd(), cli.flags.cplaceversion);
+    checkNodeVersion();
 
     if (cli.flags.plugin !== null && !cli.flags.plugin) {
         console.error(cerr`Missing value for --plugin|-p argument`);
@@ -182,8 +189,8 @@ function run(updateDetails?: IUpdateDetails) {
     if (
         !path.basename(process.cwd()).includes('main') &&
         fs.existsSync(path.join(process.cwd(), 'node_modules')) &&
-        (cplaceVersion.major < 23 ||
-            (cplaceVersion.major === 23 && cplaceVersion.minor === 1))
+        (CplaceVersion.get().major < 23 ||
+            (CplaceVersion.get().major === 23 && CplaceVersion.get().minor === 1))
     ) {
         console.error(cerr`Please remove node_modules folder from your project root. \n
         node_modules folder is not allowed in repos that are not main/cplace below release 23.2 \n 
@@ -208,6 +215,7 @@ function run(updateDetails?: IUpdateDetails) {
             withYaml: cli.flags.withYaml,
             noParents: cli.flags.noparents || cli.flags.noParents,
             packagejson: cli.flags.packagejson,
+            cplaceversion: cli.flags.cplaceversion,
         };
 
         console.log(getAvailableStats());
@@ -253,7 +261,7 @@ function run(updateDetails?: IUpdateDetails) {
 function checkNodeVersion(): void {
     const nodeVersionUtils = new NodeVersionUtils();
 
-    if (cplaceVersion.major <= 5 && cplaceVersion.minor <= 18) {
+    if (CplaceVersion.get().major <= 5 && CplaceVersion.get().minor <= 18) {
         console.log(
             `⟲ cplaceVersion ${CplaceVersion.toString()} is less or equal to 5.18.0 -> assuming node version is correct`
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,8 @@ function run(updateDetails?: IUpdateDetails) {
         !path.basename(process.cwd()).includes('main') &&
         fs.existsSync(path.join(process.cwd(), 'node_modules')) &&
         (CplaceVersion.get().major < 23 ||
-            (CplaceVersion.get().major === 23 && CplaceVersion.get().minor === 1))
+            (CplaceVersion.get().major === 23 &&
+                CplaceVersion.get().minor === 1))
     ) {
         console.error(cerr`Please remove node_modules folder from your project root. \n
         node_modules folder is not allowed in repos that are not main/cplace below release 23.2 \n 

--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -70,6 +70,11 @@ export interface IAssetsCompilerConfiguration {
      * Indicates that package.json files will be created in the root and each plugin that has assets.
      */
     packagejson: boolean;
+
+    /**
+     * Explicitly sets the current cplace version.
+     */
+    cplaceversion: string;
 }
 
 /**

--- a/src/model/CplaceVersion.ts
+++ b/src/model/CplaceVersion.ts
@@ -13,7 +13,7 @@ export class CplaceVersion {
         public readonly major: number,
         public readonly minor: number,
         public readonly patch: number,
-        public readonly snapshot: boolean
+        public readonly appendix: string
     ) {}
 
     public static initialize(
@@ -49,12 +49,7 @@ export class CplaceVersion {
                     cwarn`[NPM] Could not find version.gradle in repo ${currentRepo}...`
                 );
                 console.warn(cwarn`[CplaceVersion] -> Assuming version 1.0.0`);
-                CplaceVersion._currentVersion = new CplaceVersion(
-                    1,
-                    0,
-                    0,
-                    false
-                );
+                CplaceVersion._currentVersion = new CplaceVersion(1, 0, 0, '');
             } else {
                 const versionFileContent = fs.readFileSync(
                     versionFilePath,
@@ -134,13 +129,14 @@ export class CplaceVersion {
             parseInt(match[1]),
             parseInt(match[2]),
             parseInt(match[3] ?? 0),
-            match[4] != null
+            match[4] ?? ''
         );
     }
 
     private static parseCurrentVersion(currentVersion: string): void {
         if (currentVersion) {
-            const versionPattern = /([0-9]+)\.([0-9]+).([0-9]+)(-SNAPSHOT)?/;
+            const versionPattern =
+                /([0-9]+)\.([0-9]+).([0-9]+)-?(SNAPSHOT|RC\.[0-9]+)?/;
             this._currentVersion = this.parseVersion(
                 currentVersion,
                 versionPattern
@@ -169,10 +165,7 @@ export class CplaceVersion {
     }
 
     public static toString(): string {
-        let version = `${this._currentVersion?.major}.${this._currentVersion?.minor}.${this._currentVersion?.patch}`;
-        if (this._currentVersion?.snapshot) {
-            version += '-SNAPSHOT';
-        }
+        let version = `${this._currentVersion?.major}.${this._currentVersion?.minor}.${this._currentVersion?.patch}-${this._currentVersion?.appendix}`;
 
         return version;
     }

--- a/src/model/CplaceVersion.ts
+++ b/src/model/CplaceVersion.ts
@@ -165,7 +165,10 @@ export class CplaceVersion {
     }
 
     public static toString(): string {
-        let version = `${this._currentVersion?.major}.${this._currentVersion?.minor}.${this._currentVersion?.patch}-${this._currentVersion?.appendix}`;
+        let version = `${this._currentVersion?.major}.${this._currentVersion?.minor}.${this._currentVersion?.patch}`;
+        if (this._currentVersion?.appendix) {
+            version += `-${this._currentVersion?.appendix}`;
+        }
 
         return version;
     }

--- a/test/CplaceVersion.test.ts
+++ b/test/CplaceVersion.test.ts
@@ -35,13 +35,13 @@ describe('test the cplace version detection', () => {
     test('cplace release version provided as parameter', () => {
         CplaceVersion.initialize(mainRepoPath, '23.1.5', true);
 
-        assertCplaceVersion(23, 1, 5, false);
+        assertCplaceVersion(23, 1, 5, '');
     });
 
     test('cplace snapshot version provided as parameter', () => {
         CplaceVersion.initialize(mainRepoPath, '23.1.5-SNAPSHOT', true);
 
-        assertCplaceVersion(23, 1, 5, true);
+        assertCplaceVersion(23, 1, 5, 'SNAPSHOT');
     });
 
     test('cplace snapshot version in curentVerison of version file', () => {
@@ -53,21 +53,33 @@ describe('test the cplace version detection', () => {
         );
 
         CplaceVersion.initialize(mainRepoPath, '', true);
-        assertCplaceVersion(23, 1, 7, true);
+        assertCplaceVersion(23, 1, 7, 'SNAPSHOT');
+    });
+
+    test('cplace RC version in curentVerison of version file', () => {
+        generateVersionGradle(
+            mainRepoPath,
+            'release/23.1',
+            '23.1',
+            '23.1.7-RC.1'
+        );
+
+        CplaceVersion.initialize(mainRepoPath, '', true);
+        assertCplaceVersion(23, 1, 7, 'RC.1');
     });
 
     test('cplace no curentVerison in version file', () => {
         generateVersionGradle(mainRepoPath, 'release/23.1', '23.1');
 
         CplaceVersion.initialize(mainRepoPath, '', true);
-        assertCplaceVersion(23, 1, 0, false);
+        assertCplaceVersion(23, 1, 0, '');
     });
 
     test('cplace only createdOnBranch in version file', () => {
         generateVersionGradle(mainRepoPath, 'release/23.2');
 
         CplaceVersion.initialize(mainRepoPath, '', true);
-        assertCplaceVersion(23, 2, 0, false);
+        assertCplaceVersion(23, 2, 0, '');
     });
 
     test('cplace customer version in currentVersion in version file', () => {
@@ -79,7 +91,7 @@ describe('test the cplace version detection', () => {
         );
 
         CplaceVersion.initialize(mainRepoPath, '', true);
-        assertCplaceVersion(3, 12, 116, true);
+        assertCplaceVersion(3, 12, 116, 'SNAPSHOT');
     });
 
     test('cplace no versions in version file', () => {
@@ -104,11 +116,11 @@ describe('test the cplace version detection', () => {
         major: number,
         minor: number,
         patch: number,
-        snapshot: boolean
+        appendix: string
     ) {
         expect(CplaceVersion.get().major).toBe(major);
         expect(CplaceVersion.get().minor).toBe(minor);
         expect(CplaceVersion.get().patch).toBe(patch);
-        expect(CplaceVersion.get().snapshot).toBe(snapshot);
+        expect(CplaceVersion.get().appendix).toBe(appendix);
     }
 });

--- a/test/CplaceVersion.test.ts
+++ b/test/CplaceVersion.test.ts
@@ -1,0 +1,114 @@
+import { CplaceVersion } from '../src/model/CplaceVersion';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tmp from 'tmp';
+import { generateVersionGradle } from './helper/TestHelpers';
+
+describe('test the cplace version detection', () => {
+    const mainRepoName = 'main';
+
+    let tmpTestFolder: tmp.DirSyncObject;
+    let basePath: string;
+    let mainRepoPath: string;
+
+    let currentCwd;
+
+    beforeEach(() => {
+        tmpTestFolder = tmp.dirSync({ unsafeCleanup: true });
+        console.log('Test data will be below: ', tmpTestFolder.name);
+        basePath = tmpTestFolder.name;
+        mainRepoPath = path.join(basePath, mainRepoName);
+
+        // generate main repo
+        fs.mkdirSync(mainRepoPath, {
+            recursive: true,
+        });
+
+        currentCwd = process.cwd();
+    });
+
+    afterEach(() => {
+        process.chdir(currentCwd);
+        tmpTestFolder.removeCallback();
+    });
+
+    test('cplace release version provided as parameter', () => {
+        CplaceVersion.initialize(mainRepoPath, '23.1.5', true);
+
+        assertCplaceVersion(23, 1, 5, false);
+    });
+
+    test('cplace snapshot version provided as parameter', () => {
+        CplaceVersion.initialize(mainRepoPath, '23.1.5-SNAPSHOT', true);
+
+        assertCplaceVersion(23, 1, 5, true);
+    });
+
+    test('cplace snapshot version in curentVerison of version file', () => {
+        generateVersionGradle(
+            mainRepoPath,
+            'release/23.1',
+            '23.1',
+            '23.1.7-SNAPSHOT'
+        );
+
+        CplaceVersion.initialize(mainRepoPath, '', true);
+        assertCplaceVersion(23, 1, 7, true);
+    });
+
+    test('cplace no curentVerison in version file', () => {
+        generateVersionGradle(mainRepoPath, 'release/23.1', '23.1');
+
+        CplaceVersion.initialize(mainRepoPath, '', true);
+        assertCplaceVersion(23, 1, 0, false);
+    });
+
+    test('cplace only createdOnBranch in version file', () => {
+        generateVersionGradle(mainRepoPath, 'release/23.2');
+
+        CplaceVersion.initialize(mainRepoPath, '', true);
+        assertCplaceVersion(23, 2, 0, false);
+    });
+
+    test('cplace customer version in currentVersion in version file', () => {
+        generateVersionGradle(
+            mainRepoPath,
+            'customer/release/23.2',
+            '23.2',
+            '3.12.116-SNAPSHOT'
+        );
+
+        CplaceVersion.initialize(mainRepoPath, '', true);
+        assertCplaceVersion(3, 12, 116, true);
+    });
+
+    test('cplace no versions in version file', () => {
+        generateVersionGradle(mainRepoPath, '');
+
+        const t = () => {
+            CplaceVersion.initialize(mainRepoPath, '', true);
+        };
+        expect(t).toThrow(Error);
+    });
+
+    test('cplace no versions in version file', () => {
+        generateVersionGradle(mainRepoPath, '');
+
+        const t = () => {
+            CplaceVersion.initialize(mainRepoPath, '', true);
+        };
+        expect(t).toThrow(Error);
+    });
+
+    function assertCplaceVersion(
+        major: number,
+        minor: number,
+        patch: number,
+        snapshot: boolean
+    ) {
+        expect(CplaceVersion.get().major).toBe(major);
+        expect(CplaceVersion.get().minor).toBe(minor);
+        expect(CplaceVersion.get().patch).toBe(patch);
+        expect(CplaceVersion.get().snapshot).toBe(snapshot);
+    }
+});

--- a/test/PackageJsonGenerator.test.ts
+++ b/test/PackageJsonGenerator.test.ts
@@ -138,6 +138,7 @@ describe('test generating a package.json file in repo root', () => {
             production: false,
             noParents: false,
             packagejson: true,
+            cplaceversion: '',
         };
 
         PackageVersion.initialize(mainRepoPath);

--- a/test/PackageJsonGenerator.test.ts
+++ b/test/PackageJsonGenerator.test.ts
@@ -39,7 +39,7 @@ describe('test generating a package.json file in repo root', () => {
         fs.mkdirSync(mainRepoPath, {
             recursive: true,
         });
-        generateVersionGradle(mainRepoPath, '22.4.0');
+        generateVersionGradle(mainRepoPath, 'release/22.4', '22.4', '22.4.0');
         platformPath = path.resolve(mainRepoPath, 'cf.cplace.platform');
         fs.mkdirSync(platformPath);
         fs.mkdirSync(path.resolve(platformPath, 'src'));
@@ -76,7 +76,7 @@ describe('test generating a package.json file in repo root', () => {
             recursive: true,
         });
         generateParentRepos(otherRepoPath, ['main']);
-        generateVersionGradle(otherRepoPath, '22.4.0');
+        generateVersionGradle(otherRepoPath, 'release/22.4', '22.4', '22.4.0');
 
         const repo2Plugin1Path = path.resolve(
             otherRepoPath,

--- a/test/helper/TestHelpers.ts
+++ b/test/helper/TestHelpers.ts
@@ -92,10 +92,22 @@ export function generateParentRepos(location: string, names: string[]): void {
     );
 }
 
-export function generateVersionGradle(location: string, version: string): void {
+export function generateVersionGradle(
+    location: string,
+    createdOnBranch: string,
+    cplaceVersion?: string,
+    currentVersion?: string
+): void {
     let content = `ext {
-        currentVersion= '${version}'
-    };`;
+        createdOnBranch= '${createdOnBranch}'
+    `;
+    if (cplaceVersion) {
+        content += `cplaceVersion='${cplaceVersion}\n`;
+    }
+    if (currentVersion) {
+        content += `currentVersion='${currentVersion}\n`;
+    }
+    content += `};`;
 
     fs.writeFileSync(path.resolve(location, 'version.gradle'), content, {
         encoding: 'utf8',


### PR DESCRIPTION
Resolves [PFM-ISSUE-24479](https://base.cplace.io/pages/tdx4jma7z368w0io1etn6lsqn/PFM-ISSUE-24479-cplace-asc-use-version-calculation-of-the-gradle-plugin)

**Checklist:**
- [x] Version updated (if applicable)
- [x] Tests added (if applicable)
- [ ] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [ ] Milestone added
- [ ] PR labels added
