### PR TITLE
PFM-ISSUE-26042: cplace-asc: implement using a private npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cplace/asc-local",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@cplace/asc-local",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "license": "ISC",
             "dependencies": {
                 "@openapitools/openapi-generator-cli": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc-local",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/model/RegistryInitializer.ts
+++ b/src/model/RegistryInitializer.ts
@@ -6,20 +6,20 @@ import * as os from 'os';
 import { existsSync } from 'fs';
 
 export class RegistryInitializer {
-    public static readonly JROG_CPLACE_NPM_REGISTRY = 'cplace-npm';
-    public static readonly JROG_CPLACE_NPM_LOCAL_REGISTRY = 'cplace-npm-local';
-    public static readonly JROG_CPLACE_ASSETS_NPM_REGISTRY =
+    public static readonly JFROG_CPLACE_NPM_REGISTRY = 'cplace-npm';
+    public static readonly JFROG_CPLACE_NPM_LOCAL_REGISTRY = 'cplace-npm-local';
+    public static readonly JFROG_CPLACE_ASSETS_NPM_REGISTRY =
         'cplace-assets-npm';
-    public static readonly JROG_REGISTRY_URL =
+    public static readonly JFROG_REGISTRY_URL =
         '//cplace.jfrog.io/artifactory/api/npm/';
     public static readonly PUBLIC_NPM_REGISTRY = 'registry.npmjs.org';
     public static readonly GRADLE_HOME = '.gradle';
     public static readonly GRADLE_PROPERTIES = 'gradle.properties';
 
     private static readonly REGISTRY_LIST = [
-        RegistryInitializer.JROG_CPLACE_NPM_REGISTRY,
-        RegistryInitializer.JROG_CPLACE_NPM_LOCAL_REGISTRY,
-        RegistryInitializer.JROG_CPLACE_ASSETS_NPM_REGISTRY,
+        RegistryInitializer.JFROG_CPLACE_NPM_REGISTRY,
+        RegistryInitializer.JFROG_CPLACE_NPM_LOCAL_REGISTRY,
+        RegistryInitializer.JFROG_CPLACE_ASSETS_NPM_REGISTRY,
         RegistryInitializer.PUBLIC_NPM_REGISTRY,
     ];
 
@@ -27,7 +27,7 @@ export class RegistryInitializer {
     private npmrcUser: string = '';
     private npmrcBasicAuthToken: string = '';
     private npmrcPath: string = '';
-    private npmRegistry: string = RegistryInitializer.JROG_CPLACE_NPM_REGISTRY;
+    private npmRegistry: string = RegistryInitializer.JFROG_CPLACE_NPM_REGISTRY;
 
     constructor() {}
 
@@ -266,19 +266,19 @@ export class RegistryInitializer {
     private getDefaultRegistryConfigItems(): string[] {
         return [
             this.getRegistryInfo(
-                RegistryInitializer.JROG_REGISTRY_URL,
+                RegistryInitializer.JFROG_REGISTRY_URL,
                 this.npmRegistry
             ),
             this.getAuthInfo(
-                RegistryInitializer.JROG_REGISTRY_URL,
+                RegistryInitializer.JFROG_REGISTRY_URL,
                 this.npmRegistry
             ),
             this.getAlwaysAuthInfo(
-                RegistryInitializer.JROG_REGISTRY_URL,
+                RegistryInitializer.JFROG_REGISTRY_URL,
                 this.npmRegistry
             ),
             this.getEmailInfo(
-                RegistryInitializer.JROG_REGISTRY_URL,
+                RegistryInitializer.JFROG_REGISTRY_URL,
                 this.npmRegistry
             ),
         ];

--- a/src/model/RegistryInitializer.ts
+++ b/src/model/RegistryInitializer.ts
@@ -27,6 +27,7 @@ export class RegistryInitializer {
     private npmrcUser: string = '';
     private npmrcBasicAuthToken: string = '';
     private npmrcPath: string = '';
+    private npmRegistry: string = RegistryInitializer.JROG_CPLACE_NPM_REGISTRY;
 
     constructor() {}
 
@@ -39,6 +40,7 @@ export class RegistryInitializer {
             if (!this.extractTokenFromEnvironment()) {
                 this.extractTokenFromGradleProps();
             }
+            this.extractNpmRegistryFromEnvironment();
 
             if (!existsSync(this.npmrcPath)) {
                 RegistryInitializer.createEmptyNmprc(this.npmrcPath);
@@ -72,6 +74,19 @@ export class RegistryInitializer {
             return true;
         }
         return false;
+    }
+
+    private extractNpmRegistryFromEnvironment(): void {
+        if (process.env.ENV_PRIVATE_NPM_REGISTRY) {
+            this.npmRegistry = process.env.ENV_PRIVATE_NPM_REGISTRY;
+            console.info(
+                `⟲ Using private npm jfrog registry '${this.npmRegistry}' from environment variables`
+            );
+        } else {
+            console.info(
+                `⟲ Using default npm jfrog registry '${this.npmRegistry}'`
+            );
+        }
     }
 
     private static getGradlePropsPath(): string {
@@ -252,19 +267,19 @@ export class RegistryInitializer {
         return [
             this.getRegistryInfo(
                 RegistryInitializer.JROG_REGISTRY_URL,
-                RegistryInitializer.JROG_CPLACE_NPM_REGISTRY
+                this.npmRegistry
             ),
             this.getAuthInfo(
                 RegistryInitializer.JROG_REGISTRY_URL,
-                RegistryInitializer.JROG_CPLACE_NPM_REGISTRY
+                this.npmRegistry
             ),
             this.getAlwaysAuthInfo(
                 RegistryInitializer.JROG_REGISTRY_URL,
-                RegistryInitializer.JROG_CPLACE_NPM_REGISTRY
+                this.npmRegistry
             ),
             this.getEmailInfo(
                 RegistryInitializer.JROG_REGISTRY_URL,
-                RegistryInitializer.JROG_CPLACE_NPM_REGISTRY
+                this.npmRegistry
             ),
         ];
     }

--- a/test/RegistryInitializer.test.ts
+++ b/test/RegistryInitializer.test.ts
@@ -175,6 +175,30 @@ describe('configuring jfrog credentials', () => {
         );
     });
 
+    test('auth token and a private npm registry can be extracted from the environment', () => {
+        process.env.ENV_CPLACE_ARTIFACTORY_ACTOR =
+            'mathilde.musterfrau@cplace.de';
+        process.env.ENV_CPLACE_ARTIFACTORY_TOKEN = 'token';
+        process.env.ENV_PRIVATE_NPM_REGISTRY = 'private-registry-fe';
+
+        const registryInitializerPrototype = setupRegistryInitializerMock();
+        jest.spyOn(console, 'info').mockImplementation();
+
+        registryInitializerPrototype.extractTokenFromEnvironment();
+        registryInitializerPrototype.extractNpmRegistryFromEnvironment();
+
+        expect(registryInitializerPrototype.npmrcUser).toEqual(
+            'mathilde.musterfrau@cplace.de'
+        );
+        expect(registryInitializerPrototype.npmrcBasicAuthToken).toEqual(
+            'bWF0aGlsZGUubXVzdGVyZnJhdUBjcGxhY2UuZGU6dG9rZW4='
+        );
+        expect(console.info).toBeCalledTimes(2);
+        expect(console.info).toHaveBeenLastCalledWith(
+            '⟲ Using private npm jfrog registry \'private-registry-fe\' from environment variables'
+        );
+    });
+
     function setupRegistryInitializerMock(
         createNpmrc: boolean = true,
         createGradleProperties: boolean = true
@@ -199,6 +223,7 @@ describe('configuring jfrog credentials', () => {
             Object.getPrototypeOf(registryInitializer);
         registryInitializerPrototype.npmrcPath = npmrcPath;
         registryInitializerPrototype.mainRepo = '';
+        registryInitializerPrototype.npmRegistry = 'cplace-npm';
         return registryInitializerPrototype;
     }
 });

--- a/test/RegistryInitializer.test.ts
+++ b/test/RegistryInitializer.test.ts
@@ -195,7 +195,7 @@ describe('configuring jfrog credentials', () => {
         );
         expect(console.info).toBeCalledTimes(2);
         expect(console.info).toHaveBeenLastCalledWith(
-            '⟲ Using private npm jfrog registry \'private-registry-fe\' from environment variables'
+            "⟲ Using private npm jfrog registry 'private-registry-fe' from environment variables"
         );
     });
 


### PR DESCRIPTION
Resolves [PFM-ISSUE-26042](https://base.cplace.io/pages/vnc8je0wa02ggl5uafvsdmqpg/PFM-ISSUE-26042-cplace-asc-implement-using-a-private-npm-registry)

**Checklist:**
- [x] Version updated (if applicable)
- [x] Tests added (if applicable)
- [x] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [x] Milestone added
- [x] PR labels added
