### PR TITLE
PFM-TASK-4864 - Use local TS if exists in 2.1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cplace/asc-local",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@cplace/asc-local",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "license": "ISC",
             "dependencies": {
                 "@openapitools/openapi-generator-cli": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc-local",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",

--- a/src/compiler/AbstractTypescriptCompiler.ts
+++ b/src/compiler/AbstractTypescriptCompiler.ts
@@ -15,7 +15,13 @@ import {
 } from '../utils';
 import * as fs from 'fs';
 import * as glob from 'glob';
-import { getProjectNodeModulesBinPath } from '../model/utils';
+import {
+    getCplaceAscNodeModulesBinPath,
+    getCplaceAscNodeModulesPath,
+    getProjectNodeModulesBinPath,
+} from '../model/utils';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
 
 export abstract class AbstractTypescriptCompiler implements ICompiler {
     private static readonly HASH_FILE = 'typings.hash';
@@ -102,6 +108,12 @@ export abstract class AbstractTypescriptCompiler implements ICompiler {
         });
 
         debug(
+            `(TypescriptCompiler) Using TypeScript version: ${execSync(
+                `${tscExecutable} --version`
+            )}`
+        );
+
+        debug(
             `(TypescriptCompiler) [${this.pluginName}] tsc return code: ${result.status}`
         );
         if (result.status !== 0) {
@@ -112,7 +124,18 @@ export abstract class AbstractTypescriptCompiler implements ICompiler {
     }
 
     private getTscExecutable(): string {
-        return path.resolve(getProjectNodeModulesBinPath(), 'tsc');
+        const localTSBin = path.resolve(
+            getCplaceAscNodeModulesBinPath(),
+            'tsc'
+        );
+        const projectTSBin = path.resolve(
+            getProjectNodeModulesBinPath(),
+            'tsc'
+        );
+        if (existsSync(localTSBin)) {
+            return localTSBin;
+        }
+        return projectTSBin;
     }
 
     private getHashFilePath(): string {

--- a/src/model/utils.ts
+++ b/src/model/utils.ts
@@ -74,6 +74,10 @@ export function getCplaceAscNodeModulesPath(): string {
     return resolve(getCplaceAscPath(), 'node_modules');
 }
 
+export function getCplaceAscNodeModulesBinPath(): string {
+    return resolve(getCplaceAscNodeModulesPath(), '.bin');
+}
+
 export function getProjectNodeModulesBinPath(): string {
     return resolve(getProjectNodeModulesPath(), '.bin');
 }


### PR DESCRIPTION
Resolves [PFM-TASK-4864](https://base.cplace.io/pages/11mkabc9yjlz6m6ua5yhe9a9i/PFM-TASK-4864-Use-local-cplace-asc-if-exists-in-2.1.x?highlightedEntityUid=page%2F11mkabc9yjlz6m6ua5yhe9a9i)

**Checklist:**
- [x] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [ ] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [ ] Milestone added
- [ ] PR labels added
