### PR TITLE
Throw proper error message if dependencies are empty

### DIFF
--- a/src/model/AssetsCompiler.ts
+++ b/src/model/AssetsCompiler.ts
@@ -393,6 +393,10 @@ export class AssetsCompiler {
 
         projects.set(pluginName, project);
 
+        if (!project.pluginDescriptor.dependencies) {
+            throw `No dependencies found for plugin ${pluginName} in ${pluginPath}`;
+        }
+
         project.pluginDescriptor.dependencies.forEach((pluginDescriptor) => {
             if (projects.has(pluginDescriptor.name)) {
                 return;


### PR DESCRIPTION
Resolves [this Discuss issue](https://discuss.cplace.io/t/failed-to-start-assets-compiler-cannot-read-properties-of-null-reading-dependencies/3849)

It happens to me from time to time that, after switching between branches of different cplace versions, where plugins have been removed or added, asc fails because the dependencies of a project are empty.

Currently, asc only throws a generic error message like this:

```
✗ Failed to start assets compiler: Cannot read properties of null (reading 'dependencies')
```

To know which project to clean, I adjust the log message of the error.

**Checklist:**
- [ ] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [x] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [ ] Milestone added
- [ ] PR labels added
