### PR TITLE
PFM-ISSUE-26854: Publish registry initializer as separate npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
             "name": "@cplace/asc-local",
             "version": "2.1.6",
             "license": "ISC",
+            "workspaces": [
+                "./src/packages/globalRegistryInitializer"
+            ],
             "dependencies": {
+                "@cplace/global-registry-initializer": "2.1.x",
                 "@openapitools/openapi-generator-cli": "2.5.2",
                 "chokidar": "3.5.3",
                 "clean-css": "5.3.2",
@@ -615,6 +619,10 @@
             "resolved": "https://cplace.jfrog.io/artifactory/api/npm/cplace-npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@cplace/global-registry-initializer": {
+            "resolved": "src/packages/globalRegistryInitializer",
+            "link": true
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -7819,6 +7827,14 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "src/packages/globalRegistryInitializer": {
+            "name": "@cplace/global-registry-initializer",
+            "version": "2.1.0",
+            "license": "ISC",
+            "bin": {
+                "cplace-reginit": "index.js"
+            }
         }
     },
     "dependencies": {
@@ -8248,6 +8264,9 @@
             "resolved": "https://cplace.jfrog.io/artifactory/api/npm/cplace-npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "@cplace/global-registry-initializer": {
+            "version": "file:src/packages/globalRegistryInitializer"
         },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",
     "main": "./index.js",
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/",
-        "access": "public"
-    },
     "scripts": {
         "test": "jest",
         "test-build": "npx ts-node tools/scripts/build.ts 0.0.0-SNAPSHOT && npm pack ./dist --pack-destination ./dist",
@@ -31,6 +27,7 @@
     "author": "collaboration Factory AG",
     "license": "ISC",
     "dependencies": {
+        "@cplace/global-registry-initializer": "2.1.x",
         "@openapitools/openapi-generator-cli": "2.5.2",
         "chokidar": "3.5.3",
         "clean-css": "5.3.2",
@@ -73,5 +70,8 @@
         "prettier": "2.5.1",
         "tmp": "0.2.1",
         "ts-jest": "27.1.5"
-    }
+    },
+    "workspaces": [
+        "./src/packages/globalRegistryInitializer"
+    ]
 }

--- a/src/model/NPMResolver.ts
+++ b/src/model/NPMResolver.ts
@@ -7,8 +7,8 @@ import * as process from 'process';
 import * as fs from 'fs';
 import * as spawn from 'cross-spawn';
 import * as crypto from 'crypto';
-import { cgreen, cwarn, debug } from '../utils';
-import { RegistryInitializer } from './RegistryInitializer';
+import { cgreen, cwarn, debug, isDebugEnabled } from '../utils';
+import { RegistryInitializer } from '@cplace/global-registry-initializer';
 
 export class NPMResolver {
     private static readonly PACKAGE_JSON = 'package.json';
@@ -241,6 +241,7 @@ export class NPMResolver {
 
     public init(): void {
         const registryInitializer = new RegistryInitializer();
+        registryInitializer.enableDebug(isDebugEnabled())
         registryInitializer.initRegistry();
     }
 }

--- a/src/packages/globalRegistryInitializer/index.ts
+++ b/src/packages/globalRegistryInitializer/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { RegistryInitializer } from "./RegistryInitializer";
+
+const registryInitializer = new RegistryInitializer();
+registryInitializer.initRegistry();
+
+export { RegistryInitializer };

--- a/src/packages/globalRegistryInitializer/package.json
+++ b/src/packages/globalRegistryInitializer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cplace/global-registry-initializer",
+  "version": "2.1.0",
+  "description": "",
+  "main": "index.js",
+  "bin": {
+    "cplace-reginit": "./index.js"
+  },
+  "repository": "git+https://github.com/collaborationFactory/cplace-asc.git",
+  "author": "",
+  "license": "ISC",
+  "homepage": "https://github.com/collaborationFactory/cplace-asc#readme"
+}

--- a/tools/scripts/build.ts
+++ b/tools/scripts/build.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { resolve } from 'path';
-import { writeFileSync, rmSync, copyFileSync, mkdirSync } from 'fs';
+import { writeFileSync, rmSync, copyFileSync, mkdirSync, readFileSync, existsSync } from 'fs';
 import * as rootPackageJSON from '../../package.json';
 import { CPLACE_ASC_DIST } from './shared';
 
@@ -47,12 +47,32 @@ const newPackageJSON = Object.keys(rootPackageJSON).reduce((acc, key) => {
     return acc;
 }, {});
 
+console.log(`Copying package.json files for each workspace`);
+const distWorskpaces: string[] = [];
+for (const workspace of rootPackageJSON.workspaces) {
+    // Remove the ./src prefix since the generated js files in the dist folder will be in the root, not in a src subfolder
+    const distWorskpace = workspace.replace("./src", ".");
+    distWorskpaces.push(distWorskpace);
+
+    const workspacePackageJson = resolve(workspace, 'package.json');
+    if (existsSync(workspacePackageJson)) {   
+        console.log(`Copying ${workspacePackageJson} to ${distWorskpace}`);
+        const workspacePackageJsonContent = JSON.parse(readFileSync(workspacePackageJson).toString());
+        const workspacePackageJsonDist = resolve(CPLACE_ASC_DIST, distWorskpace, 'package.json');
+        writeFileSync(
+            workspacePackageJsonDist,
+            JSON.stringify({ ...workspacePackageJsonContent, version: version })
+        );
+    }
+}
+
 console.log(`Creating package.json for version ${version}...`);
 writeFileSync(
     PACKAGE_JSON_DIST,
-    JSON.stringify({ ...newPackageJSON, version: version })
+    JSON.stringify({ ...newPackageJSON, version: version, workspaces: distWorskpaces })
 );
 console.log('package.json CREATED!');
+
 copyFileSync(
     `${OPENAPI_TOOLS}/${OPENAPI_TOOLS_JSON}`,
     resolve(CPLACE_ASC_DIST, OPENAPI_TOOLS_JSON)

--- a/tools/scripts/publish.ts
+++ b/tools/scripts/publish.ts
@@ -17,5 +17,5 @@ console.log(execSync(`npx ts-node ${buildScriptPath} ${version}`).toString());
 console.log(`cplace-asc successfully built!`);
 process.chdir(CPLACE_ASC_DIST);
 console.log(`Publishing cplace-asc...`);
-execSync(`npm publish ${isSnapshot ? '--tag snapshot' : ''}`);
+execSync(`npm publish --workspaces --include-workspace-root ${isSnapshot ? '--tag snapshot' : ''}`);
 console.log(`cplace-asc published!`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "outDir": "./dist",
         "resolveJsonModule": true
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "packages/**/*"],
     "exclude": ["**/*.spec.ts"],
     "compileOnSave": true
 }


### PR DESCRIPTION
Resolves [PFM-ISSUE-26854](https://base.cplace.io/pages/h32lh81ck6l4i43a68iu6d7dw/PFM-ISSUE-26854-Publish-registry-initializer-as-separate-npm-package)

**Checklist:**
- [ ] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [ ] Code formatted
- [ ] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [ ] Milestone added
- [ ] PR labels added
