### PR TITLE
PFM-TASK-6033 - Fix node version to 18.19.1 in cplace-asc 2.2.x branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cplace/asc-local",
-    "version": "2.1.8",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cplace/asc-local",
-            "version": "2.1.8",
+            "version": "2.2.0",
             "license": "ISC",
             "dependencies": {
                 "@openapitools/openapi-generator-cli": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cplace/asc-local",
-    "version": "2.1.8",
+    "version": "2.2.0",
     "description": "cplace assets compiler",
     "repository": "https://github.com/collaborationFactory/cplace-asc",
     "homepage": "https://github.com/collaborationFactory/cplace-asc",


### PR DESCRIPTION
Update Node.js version to 18.18.2 in configuration files

Resolves [PFM-TASK-6033](https://base.cplace.io/pages/egrihpdhux4glg8q9a1gudzwy/PFM-TASK-6033-Fix-node-version-to-18.19.1-in-cplace-asc-2.2.x-branch)

**Checklist:**
- [x] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [x] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [x] Milestone added
- [x] PR labels added
