### PR TITLE
PFM-ISSUE-32338: Enable OIDC trusted publishing for cplace-cli and cplace-asc on npmjs.org

### DIFF
--- a/.github/workflows/push_tag.yml
+++ b/.github/workflows/push_tag.yml
@@ -9,8 +9,11 @@ env:
     NODE_ENV: 'production'
 
 jobs:
-    publish:
+    build:
         runs-on: ubuntu-latest
+        outputs:
+            tgz_filename: ${{ steps.pack.outputs.tgz_filename }}
+            is_snapshot: ${{ steps.pack.outputs.is_snapshot }}
         steps:
             - name: Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.9.1
@@ -29,7 +32,6 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: '18.18.2'
-                  registry-url: 'https://registry.npmjs.org'
 
             - name: Cache Node Modules
               id: npm-cache
@@ -42,8 +44,56 @@ jobs:
               if: steps.npm-cache.outputs.cache-hit != 'true'
               run: npm ci
 
-            - name: Publish
-              run: npx ts-node tools/scripts/publish.ts
+            - name: Build and Pack
+              id: pack
+              run: |
+                  npx ts-node tools/scripts/build-and-pack.ts
+                  # Extract version from tag
+                  VERSION="${{ steps.tag.outputs.tag }}"
+                  VERSION="${VERSION#v}"
+                  IS_SNAPSHOT="false"
+                  if [[ "$VERSION" == *"SNAPSHOT"* ]]; then
+                      IS_SNAPSHOT="true"
+                  fi
+                  # The tgz filename follows npm naming convention
+                  TGZ_FILENAME="cplace-asc-local-${VERSION}.tgz"
+                  echo "tgz_filename=${TGZ_FILENAME}" >> $GITHUB_OUTPUT
+                  echo "is_snapshot=${IS_SNAPSHOT}" >> $GITHUB_OUTPUT
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   TAG: ${{ steps.tag.outputs.tag }}
+
+            - name: Upload package artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: npm-package
+                  path: dist/${{ steps.pack.outputs.tgz_filename }}
+                  retention-days: 1
+
+    publish:
+        runs-on: ubuntu-latest
+        needs: build
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - name: Download package artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: npm-package
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Publish to npm
+              run: |
+                  TGZ_FILE="${{ needs.build.outputs.tgz_filename }}"
+                  IS_SNAPSHOT="${{ needs.build.outputs.is_snapshot }}"
+                  echo "Publishing ${TGZ_FILE}..."
+                  echo "Is snapshot: ${IS_SNAPSHOT}"
+                  if [ "${IS_SNAPSHOT}" = "true" ]; then
+                      npm publish "${TGZ_FILE}" --provenance --access public --tag snapshot
+                  else
+                      npm publish "${TGZ_FILE}" --provenance --access public
+                  fi

--- a/.github/workflows/push_tag.yml
+++ b/.github/workflows/push_tag.yml
@@ -48,17 +48,6 @@ jobs:
               id: pack
               run: |
                   npx ts-node tools/scripts/build-and-pack.ts
-                  # Extract version from tag
-                  VERSION="${{ steps.tag.outputs.tag }}"
-                  VERSION="${VERSION#v}"
-                  IS_SNAPSHOT="false"
-                  if [[ "$VERSION" == *"SNAPSHOT"* ]]; then
-                      IS_SNAPSHOT="true"
-                  fi
-                  # The tgz filename follows npm naming convention
-                  TGZ_FILENAME="cplace-asc-local-${VERSION}.tgz"
-                  echo "tgz_filename=${TGZ_FILENAME}" >> $GITHUB_OUTPUT
-                  echo "is_snapshot=${IS_SNAPSHOT}" >> $GITHUB_OUTPUT
               env:
                   TAG: ${{ steps.tag.outputs.tag }}
 
@@ -70,6 +59,7 @@ jobs:
                   retention-days: 1
 
     publish:
+        name: Trusted Publish to NPM
         runs-on: ubuntu-latest
         needs: build
         permissions:
@@ -93,7 +83,7 @@ jobs:
                   echo "Publishing ${TGZ_FILE}..."
                   echo "Is snapshot: ${IS_SNAPSHOT}"
                   if [ "${IS_SNAPSHOT}" = "true" ]; then
-                      npm publish "${TGZ_FILE}" --provenance --access public --tag snapshot
+                      npm publish "${TGZ_FILE}" --tag snapshot
                   else
-                      npm publish "${TGZ_FILE}" --provenance --access public
+                      npm publish "${TGZ_FILE}"
                   fi

--- a/tools/scripts/build-and-pack.ts
+++ b/tools/scripts/build-and-pack.ts
@@ -39,9 +39,9 @@ console.log(`Created package: ${tgzFilename}`);
 const githubOutput = process.env.GITHUB_OUTPUT;
 
 if (githubOutput) {
-  appendFileSync(githubOutput, `tgz_filename=${tgzFilename}\n`);
-  appendFileSync(githubOutput, `is_snapshot=${isSnapshot}\n`);
-  appendFileSync(githubOutput, `version=${version}\n`);
+    appendFileSync(githubOutput, `tgz_filename=${tgzFilename}\n`);
+    appendFileSync(githubOutput, `is_snapshot=${isSnapshot}\n`);
+    appendFileSync(githubOutput, `version=${version}\n`);
 }
 
 console.log(`cplace-asc packed successfully!`);

--- a/tools/scripts/build-and-pack.ts
+++ b/tools/scripts/build-and-pack.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { appendFileSync } from 'fs';
 import { CPLACE_ASC_DIST } from './shared';
 import { resolve } from 'path';
 
@@ -34,8 +35,13 @@ const tgzFilename = packOutput.split('\n').pop()?.trim();
 console.log(`Created package: ${tgzFilename}`);
 
 // Output information for the next job
-console.log(`::set-output name=tgz_filename::${tgzFilename}`);
-console.log(`::set-output name=is_snapshot::${isSnapshot}`);
-console.log(`::set-output name=version::${version}`);
+
+const githubOutput = process.env.GITHUB_OUTPUT;
+
+if (githubOutput) {
+  appendFileSync(githubOutput, `tgz_filename=${tgzFilename}\n`);
+  appendFileSync(githubOutput, `is_snapshot=${isSnapshot}\n`);
+  appendFileSync(githubOutput, `version=${version}\n`);
+}
 
 console.log(`cplace-asc packed successfully!`);

--- a/tools/scripts/build-and-pack.ts
+++ b/tools/scripts/build-and-pack.ts
@@ -22,7 +22,11 @@ console.log(execSync(`npx ts-node ${buildScriptPath} ${version}`).toString());
 console.log(`cplace-asc successfully built!`);
 
 console.log(`Packing cplace-asc...`);
-const packOutput = execSync(`npm pack ${CPLACE_ASC_DIST} --pack-destination ${CPLACE_ASC_DIST}`).toString().trim();
+const packOutput = execSync(
+    `npm pack ${CPLACE_ASC_DIST} --pack-destination ${CPLACE_ASC_DIST}`
+)
+    .toString()
+    .trim();
 console.log(`Pack output: ${packOutput}`);
 
 // The pack output is the filename of the created tgz

--- a/tools/scripts/build-and-pack.ts
+++ b/tools/scripts/build-and-pack.ts
@@ -1,0 +1,37 @@
+import { execSync } from 'child_process';
+import { CPLACE_ASC_DIST } from './shared';
+import { resolve } from 'path';
+
+const tag = process.env.TAG;
+
+if (!tag) {
+    throw Error('No tag provided!');
+}
+
+const version = tag.split('v')[1];
+
+if (!version) {
+    throw Error('Could not extract version from tag!');
+}
+
+const isSnapshot = version.includes('SNAPSHOT');
+
+console.log(`Building cplace-asc version ${version}...`);
+const buildScriptPath = resolve(__dirname, 'build.ts');
+console.log(execSync(`npx ts-node ${buildScriptPath} ${version}`).toString());
+console.log(`cplace-asc successfully built!`);
+
+console.log(`Packing cplace-asc...`);
+const packOutput = execSync(`npm pack ${CPLACE_ASC_DIST} --pack-destination ${CPLACE_ASC_DIST}`).toString().trim();
+console.log(`Pack output: ${packOutput}`);
+
+// The pack output is the filename of the created tgz
+const tgzFilename = packOutput.split('\n').pop()?.trim();
+console.log(`Created package: ${tgzFilename}`);
+
+// Output information for the next job
+console.log(`::set-output name=tgz_filename::${tgzFilename}`);
+console.log(`::set-output name=is_snapshot::${isSnapshot}`);
+console.log(`::set-output name=version::${version}`);
+
+console.log(`cplace-asc packed successfully!`);


### PR DESCRIPTION
Resolves [PFM-ISSUE-32338](https://base.cplace.io/pages/arpi39yf67jp3kgh5c3xtri2v/PFM-ISSUE-32338-Enable-OIDC-trusted-publishing-for-cplace-cli-and-cplace-asc-on-npmjs.org)

**Checklist:**
- [ ] Version updated (if applicable)
- [ ] Tests added (if applicable)
- [ ] Code formatted
- [x] Chosen correct branch as a merge target (For @cplace/asc use the legacy-asc branch, for @cplace/asc-local use master, or a release branch like 2.x.x etc.)
- [x] Milestone added
- [x] PR labels added
